### PR TITLE
Add Orderly volume to backup config

### DIFF
--- a/src/backup.py
+++ b/src/backup.py
@@ -14,7 +14,8 @@ def configure(settings):
         template = f.read()
     config = pystache.render(template, {
         "s3_bucket": settings["backup_bucket"],
-        "db_container": service.db_name
+        "db_container": service.db_name,
+        "orderly_volume": service.orderly_volume_name
     })
     makedirs("/etc/montagu/backup", exist_ok=True)
     with open("/etc/montagu/backup/config.json", 'w') as f:


### PR DESCRIPTION
After merging [the PR for the submodule](https://github.com/vimc/montagu-backup/pull/1) you should update this repo (or ask me to) so that it points at master in the submodule.

https://vimc.myjetbrains.com/youtrack/issue/VIMC-489