### PR TITLE
I632 - check deploy environment is clean

### DIFF
--- a/src/deploy.py
+++ b/src/deploy.py
@@ -15,7 +15,7 @@ from service import service
 from service_config import configure_api, configure_proxy
 from service_config.api_config import get_token_keypair, configure_reporting_api
 from settings import get_settings
-
+from git import git_check
 
 def migrate_schema(db_password):
     pass
@@ -33,6 +33,9 @@ def _deploy():
         print("Montagu status: {}. Data volume present: {}".format(status, volume_present))
 
     settings = get_settings(is_first_time)
+
+    # Check that the deployment environment is clean enough
+    git_check(settings)
 
     # If Montagu is running, back it up before tampering with it
     if (status == "running") and settings["backup"]:

--- a/src/git.py
+++ b/src/git.py
@@ -19,6 +19,11 @@ from subprocess import run, PIPE
 # machine, so it would be good if that did not happen.
 def git_check(settings):
     strict = settings["backup"]
+    def report(msg):
+        if strict:
+            raise Exception(msg)
+        else:
+            print("NOTE: " + msg)
 
     sha = git_sha()
     if not sha:
@@ -28,11 +33,6 @@ def git_check(settings):
 
     is_clean = git_is_clean()
 
-    def report(msg):
-        if strict:
-            raise Exception(msg)
-        else:
-            print("NOTE: " + msg)
 
     if not is_clean:
         report("git status reports directory is unclean")

--- a/src/git.py
+++ b/src/git.py
@@ -45,7 +45,8 @@ def git_check(settings):
     print("This is montagu {tag} ({sha})".format(tag = tag, sha = sha))
 
 def git_is_clean():
-    p = run(["git", "status", "-s"], stdout = PIPE, stderr = PIPE)
+    p = run(["git", "status", "-s"], stdout = PIPE, stderr = PIPE,
+            check = True)
     return len(p.stdout) == 0
 
 def git_get_tag(ref):

--- a/src/git.py
+++ b/src/git.py
@@ -1,0 +1,57 @@
+from subprocess import run, PIPE
+
+# The idea here is to prevent deploying into production a system that
+# is untagged and/or has a dirty git status (the latter is most
+# commonly triggered by a submodule being out of date - seen with the
+# backup module).
+#
+# We only want this on production really.  We detect this by looking
+# to see if 'backup' is selected (this will be false for all but
+# production).
+#
+# It would be easy enough to add a check to ensure that the tag
+# actually exists on the remote machine, but that requires
+#
+#   git ls-remote --tags {remote} refs/tags/{tag}
+#
+# and that *does* use the network which slows things down a little.
+# This is only an issue if people are tagging on the production
+# machine, so it would be good if that did not happen.
+def git_check(settings):
+    strict = settings["backup"]
+
+    is_clean = git_is_clean()
+    sha = git_sha()
+    tag = git_get_tag(sha)
+
+    def report(msg):
+        if strict:
+            raise Exception(msg)
+        else:
+            print("NOTE: " + msg)
+
+    if not is_clean:
+        report("git status reports directory is unclean")
+    if not tag:
+        report("HEAD is not tagged")
+        tag = "<<UNTAGGED>>"
+
+    print("This is montagu {tag} ({sha})".format(tag = tag, sha = sha))
+
+def git_is_clean():
+    p = run(["git", "status", "-s"], stdout = PIPE, stderr = PIPE)
+    return len(p.stdout) == 0
+
+def git_get_tag(ref):
+    args = ["git", "describe", "--tags", "--exact-match", ref]
+    p = run(args, stdout = PIPE, stderr = PIPE)
+    if p.returncode == 0:
+        tag = p.stdout.decode("utf-8").strip()
+    else:
+        tag = None
+    return tag
+
+def git_sha():
+    args = ["git", "rev-parse", "HEAD"]
+    p = run(args, stdout = PIPE, stderr = PIPE, check = True)
+    return p.stdout.decode("utf-8").strip()

--- a/src/git.py
+++ b/src/git.py
@@ -62,6 +62,11 @@ def git_sha():
     args = ["git", "rev-parse", "HEAD"]
     p = run(args, stdout = PIPE, stderr = PIPE)
     code = p.returncode
+    # Emprically, on teamcity, when this is run out of the git tree
+    # git returns error code 128.  Unfortunately this seems to be a
+    # bit of a catchall error and I can't find any documentation as to
+    # whether we can rely on it.  For all general use we expect
+    # deployment to happen from the git tree though.
     if code == 128:
         return None
     elif code == 0:

--- a/src/git.py
+++ b/src/git.py
@@ -18,7 +18,7 @@ from subprocess import run, PIPE
 # This is only an issue if people are tagging on the production
 # machine, so it would be good if that did not happen.
 def git_check(settings):
-    strict = settings["backup"]
+    strict = settings["require_clean_git"]
     def report(msg):
         if strict:
             raise Exception(msg)

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -80,8 +80,14 @@ definitions = [
                       is_required=vault_required),
     BooleanSettingDefinition("clone_reports",
                              "Should montagu-reports be cloned?",
-                             "If you answer yes, then we need vault access in order to get the ssh keys for vimc-robot"
-                             "If you answer no, then we set up only an empty orderly repository, and you will not be"
+                             "If you answer yes, then we need vault access in order to get the ssh keys for vimc-robot "
+                             "If you answer no, then we set up only an empty orderly repository, and you will not be "
                              "able to clone the reports repository",
-                             default_value=True)
+                             default_value=True),
+    BooleanSettingDefinition("require_clean_git",
+                             "Should we require a clean git state?",
+                             "If you answer yes, then we require that git is 'clean' (no untracked or modified files) "
+                             "and tagged before deploying.  This is the desired setting on production machines, but "
+                             "will be annoying for development",
+                             default_value=False)
 ]

--- a/teamcity-settings.json
+++ b/teamcity-settings.json
@@ -7,5 +7,6 @@
     "certificate": "self_signed",
     "backup": false,
     "use_real_passwords": false,
-    "clone_reports": false
+    "clone_reports": false,
+    "require_clean_git": false
 }


### PR DESCRIPTION
The idea here is to prevent deploying into production a system that
is untagged and/or has a dirty git status (the latter is most
commonly triggered by a submodule being out of date - seen with the
backup module).

We only want this on production really.  We detect this by looking
to see if 'backup' is selected (this will be false for all but
production).
