### PR TITLE
i704 Clean up migration container on exit

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -130,6 +130,7 @@ def migrate_schema(db_password):
     run(["docker", "pull", image], check=True)
     run([
         "docker", "run",
+        "--rm",
         "--network=" + network_name,
         image,
         "migrate", "-user=" + root_user, "-password=" + db_password


### PR DESCRIPTION
This should be straightforward but will stop leaving around unneeded containers after stopping montagu

```
rich@wpia-dide136 ~/Documents/Projects/epi/vimc/montagu $ docker ps -a
CONTAINER ID        IMAGE                                                       COMMAND                  CREATED             STATUS                      PORTS                    NAMES
d7ba961b4bc6        docker.montagu.dide.ic.ac.uk:5000/montagu-migrate:6d203bf   "flyway migrate -u..."   13 minutes ago      Exited (0) 13 minutes ago                            unruffled_torvalds
```