### PR TITLE
i952 Initialise the orderly volume on consecutive minimal deploys

### DIFF
--- a/src/deploy.py
+++ b/src/deploy.py
@@ -70,11 +70,12 @@ def _deploy():
 
 def configure_montagu(is_first_time, settings):
     # Do things to the database
-    if (not is_first_time) and settings["persist_data"]:
+    data_exists = (not is_first_time) and settings["persist_data"]
+    if data_exists:
         print("Skipping data import: 'persist_data' is set, and this is not a first-time deployment")
     else:
         data_import.do(settings)
-    orderly.configure_orderly(is_first_time, settings)
+    orderly.configure_orderly(not data_exists, settings)
 
     passwords = database.setup(settings["use_real_passwords"])
 

--- a/src/orderly.py
+++ b/src/orderly.py
@@ -13,12 +13,12 @@ from service import orderly_volume_name
 
 orderly_ssh_keypath = ""
 
-def configure_orderly(is_first_time, settings):
+def configure_orderly(initialise_volume, settings):
     ## Run this one first because we might need to use the ssh keys to
     ## clone:
     configure_orderly_ssh(settings)
     ## Then this requires an empty directory:
-    if is_first_time and settings["initial_data_source"] != "restore":
+    if initialise_volume and settings["initial_data_source"] != "restore":
         print("Setting up orderly store")
         initialise_orderly_store(settings)
     ## Then set up some passwords


### PR DESCRIPTION
This fixes the bug that Martin found; it's not just the `is_first_time`
setting I need to pass through but also the persist data.