### PR TITLE
i1052 - Post in slack as deploy begins/ends

### DIFF
--- a/src/deploy.py
+++ b/src/deploy.py
@@ -40,7 +40,7 @@ def _deploy():
 
     deploy_str = "montagu {} (`{}`) on `{}`".format(
         version['tag'] or "(untagged)", version['sha'][:7],
-        settings['notify_instance_name'])
+        settings['instance_name'])
 
     notifier.post("*Starting* deploy of " + deploy_str)
 
@@ -51,7 +51,7 @@ def _deploy():
     # Stop Montagu if it is running (and delete data volume if persist_data is False)
     if not is_first_time:
         notifier.post("*Stopping* previous montagu on `{}` :hand:".format(
-            settings['notify_instance_name']))
+            settings['instance_name']))
         service.stop(settings)
 
     # Schedule backups

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -39,7 +39,8 @@ def _deploy():
     version = git_check(settings)
 
     deploy_str = "montagu {} ({}) on {}".format(
-        version['tag'], version['sha'][:7], settings['notify_instance_name'])
+        version['tag'] or "(untagged)", version['sha'][:7],
+        settings['notify_instance_name'])
 
     notifier.post("Starting deploy of " + deploy_str)
 
@@ -50,7 +51,7 @@ def _deploy():
     # Stop Montagu if it is running (and delete data volume if persist_data is False)
     if not is_first_time:
         notifier.post("Stopping previous montagu on " +
-                      settings['notify_instance_name'])
+                      settings['notify_instance_name'] + " :hand:")
         service.stop(settings)
 
     # Schedule backups
@@ -66,7 +67,7 @@ def _deploy():
         print(e)
         service.stop(settings)
         try:
-            notifier.post(":bomb: Failed deploy of " + deploy_str)
+            notifier.post("Failed deploy of " + deploy_str + " :bomb:")
         except:
             pass
         raise
@@ -75,7 +76,7 @@ def _deploy():
         add_test_user()
 
     last_deploy_update(version)
-    notifier.post(":shipit: Completed deploy of " + deploy_str)
+    notifier.post("Completed deploy of " + deploy_str + " :shipit:")
 
     print("Finished deploying Montagu")
     if settings["open_browser"]:

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -38,11 +38,11 @@ def _deploy():
     # Check that the deployment environment is clean enough
     version = git_check(settings)
 
-    deploy_str = "montagu {} ({}) on {}".format(
+    deploy_str = "montagu {} (`{}`) on `{}`".format(
         version['tag'] or "(untagged)", version['sha'][:7],
         settings['notify_instance_name'])
 
-    notifier.post("Starting deploy of " + deploy_str)
+    notifier.post("*Starting* deploy of " + deploy_str)
 
     # If Montagu is running, back it up before tampering with it
     if (status == "running") and settings["backup"]:
@@ -50,7 +50,7 @@ def _deploy():
 
     # Stop Montagu if it is running (and delete data volume if persist_data is False)
     if not is_first_time:
-        notifier.post("Stopping previous montagu on " +
+        notifier.post("*Stopping* previous montagu on " +
                       settings['notify_instance_name'] + " :hand:")
         service.stop(settings)
 
@@ -67,7 +67,7 @@ def _deploy():
         print(e)
         service.stop(settings)
         try:
-            notifier.post("Failed deploy of " + deploy_str + " :bomb:")
+            notifier.post("*Failed* deploy of " + deploy_str + " :bomb:")
         except:
             pass
         raise
@@ -76,7 +76,7 @@ def _deploy():
         add_test_user()
 
     last_deploy_update(version)
-    notifier.post("Completed deploy of " + deploy_str + " :shipit:")
+    notifier.post("*Completed* deploy of " + deploy_str + " :shipit:")
 
     print("Finished deploying Montagu")
     if settings["open_browser"]:

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -18,6 +18,7 @@ from service_config import configure_api, configure_proxy
 from service_config.api_config import get_token_keypair, configure_reporting_api
 from settings import get_settings
 from last_deploy import last_deploy_update
+from notify import Notifier
 
 
 def _deploy():
@@ -32,9 +33,15 @@ def _deploy():
         print("Montagu status: {}. Data volume present: {}".format(status, volume_present))
 
     settings = get_settings(is_first_time)
+    notifier = Notifier(settings['notify_channel'])
 
     # Check that the deployment environment is clean enough
     version = git_check(settings)
+
+    deploy_str = "montagu {} ({}) on {}".format(
+        version['tag'], version['sha'][:7], settings['notify_instance_name'])
+
+    notifier.post("Starting deploy of " + deploy_str)
 
     # If Montagu is running, back it up before tampering with it
     if (status == "running") and settings["backup"]:
@@ -42,6 +49,8 @@ def _deploy():
 
     # Stop Montagu if it is running (and delete data volume if persist_data is False)
     if not is_first_time:
+        notifier.post("Stopping previous montagu on " +
+                      settings['notify_instance_name'])
         service.stop(settings)
 
     # Schedule backups
@@ -56,12 +65,17 @@ def _deploy():
         print("An error occurred before deployment could be completed. Stopping Montagu")
         print(e)
         service.stop(settings)
+        try:
+            notifier.post(":bomb: Failed deploy of " + deploy_str)
+        except:
+            pass
         raise
 
     if settings["add_test_user"] is True:
         add_test_user()
 
     last_deploy_update(version)
+    notifier.post(":shipit: Completed deploy of " + deploy_str)
 
     print("Finished deploying Montagu")
     if settings["open_browser"]:

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -50,8 +50,8 @@ def _deploy():
 
     # Stop Montagu if it is running (and delete data volume if persist_data is False)
     if not is_first_time:
-        notifier.post("*Stopping* previous montagu on " +
-                      settings['notify_instance_name'] + " :hand:")
+        notifier.post("*Stopping* previous montagu on `{}` :hand:".format(
+            settings['notify_instance_name']))
         service.stop(settings)
 
     # Schedule backups

--- a/src/notify.py
+++ b/src/notify.py
@@ -1,0 +1,23 @@
+from settings import get_secret
+import requests
+import json
+
+class Notifier:
+    def __init__(self, channel):
+        path = get_secret('slack/deploy-webhook')
+        self.enabled = len(channel) > 0
+        self.url = 'https://hooks.slack.com/services/{}'.format(path)
+        self.channel = "#" + channel
+        self.username = "montagu-bot"
+        self.icon = ":robot_face:"
+        self.headers = {'Content-Type': 'application/json'}
+    def post(self, message):
+        if not self.enabled:
+            return
+        data = json.dumps({"text": message,
+                           "channel": self.channel,
+                           "username": self.username,
+                           "icon_emoji": self.icon})
+        r = requests.post(self.url, data=data, headers=self.headers)
+        if r.status_code >= 300:
+            raise Exception("Error sending message: " + r.reason)

--- a/src/notify.py
+++ b/src/notify.py
@@ -4,13 +4,14 @@ import json
 
 class Notifier:
     def __init__(self, channel):
-        path = get_secret('slack/deploy-webhook')
         self.enabled = len(channel) > 0
-        self.url = 'https://hooks.slack.com/services/{}'.format(path)
-        self.channel = "#" + channel
-        self.username = "montagu-bot"
-        self.icon = ":robot_face:"
-        self.headers = {'Content-Type': 'application/json'}
+        if self.enabled:
+            path = get_secret('slack/deploy-webhook')
+            self.url = 'https://hooks.slack.com/services/{}'.format(path)
+            self.channel = "#" + channel
+            self.username = "montagu-bot"
+            self.icon = ":robot_face:"
+            self.headers = {'Content-Type': 'application/json'}
     def post(self, message):
         if not self.enabled:
             return

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,4 +3,3 @@ requests==2.17.3
 pystache==0.5.4
 psycopg2==2.7.3
 docopt
-requests

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,3 +3,4 @@ requests==2.17.3
 pystache==0.5.4
 psycopg2==2.7.3
 docopt
+requests

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -85,6 +85,15 @@ definitions = [
                       "Otherwise, just use the default",
                       default_value="https://support.montagu.dide.ic.ac.uk:8200",
                       is_required=vault_required),
+
+    SettingDefinition("notify_channel",
+                      "What slack channel should we post in?",
+                      "e.g., montagu. Leave as the empty string to not post",
+                      default_value=""),
+    SettingDefinition("notify_instance_name",
+                      "What is the name of this instance to post in a channel?",
+                      default_value="(unknown)"),
+
     BooleanSettingDefinition("clone_reports",
                              "Should montagu-reports be cloned?",
                              "If you answer yes, then we need vault access in order to get the ssh keys for vimc-robot "

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -16,7 +16,7 @@ def vault_required(settings):
            or settings["certificate"] == "production" \
            or settings["certificate"] == "support" \
            or uses_vault_passwords \
-           or settings["notify_channel"] != "" \
+           or settings["notify_channel"] \
            or ("clone_reports" in settings and settings["clone_reports"] is True)
 
 
@@ -91,7 +91,7 @@ definitions = [
                       "What slack channel should we post in?",
                       "e.g., montagu. Leave as the empty string to not post",
                       default_value=""),
-    SettingDefinition("notify_instance_name",
+    SettingDefinition("instance_name",
                       "What is the name of this instance to post in a channel?",
                       default_value="(unknown)"),
 

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -16,6 +16,7 @@ def vault_required(settings):
            or settings["certificate"] == "production" \
            or settings["certificate"] == "support" \
            or uses_vault_passwords \
+           or settings["notify_channel"] != "" \
            or ("clone_reports" in settings and settings["clone_reports"] is True)
 
 

--- a/teamcity-settings.json
+++ b/teamcity-settings.json
@@ -10,6 +10,6 @@
     "clone_reports": false,
     "require_clean_git": false,
     "add_test_user": false,
-    "instance_name": "",
+    "instance_name": "teamcity",
     "notify_channel": ""
 }

--- a/teamcity-settings.json
+++ b/teamcity-settings.json
@@ -9,7 +9,7 @@
     "password_group": "fake",
     "clone_reports": false,
     "require_clean_git": false,
-    "add_test_user": false
+    "add_test_user": false,
     "notify_instance_name": "",
     "notify_channel": ""
 }

--- a/teamcity-settings.json
+++ b/teamcity-settings.json
@@ -10,4 +10,6 @@
     "clone_reports": false,
     "require_clean_git": false,
     "add_test_user": false
+    "notify_instance_name": "",
+    "notify_channel": ""
 }

--- a/teamcity-settings.json
+++ b/teamcity-settings.json
@@ -10,6 +10,6 @@
     "clone_reports": false,
     "require_clean_git": false,
     "add_test_user": false,
-    "notify_instance_name": "",
+    "instance_name": "",
     "notify_channel": ""
 }


### PR DESCRIPTION
This will hopefully reduce the number of "is montagu being deployed" or "why is my connection not working" questions.  Uses slack incoming webhooks, with the address stored in the vault.

This adds two more settings (I don't think they can sensibly be combined into one) - the channel to post into and the name of the deployment.

To test, just set these as something like

```
    "notify_channel": "montagu-deploy",
    "instance_name": "local (rich)",
```

and on deploy it will print a message as deployment starts, previous versions are brought down and on completion or error.  An example is in #montagu-deploy now
