### PR TITLE
i1063 - Add blank line in release message

### DIFF
--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -54,6 +54,7 @@ def get_new_tag():
 def make_release_message(tag, branches_and_tickets):
     with StringIO() as msg:
         print("# " + tag, file=msg)
+        print("", file=msg)
         print("## Tickets", file=msg)
         for branch, ticket in branches_and_tickets:
             if ticket:


### PR DESCRIPTION
This makes the git commit message conform to the conventional format,
with a blank line following the title before the body.  This is
expected by tooling around git (including things like `git log --oneline`)
which will run all the lines together if the blank line is not there.