### PR TITLE
i979 - deploy from docker hub

### DIFF
--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -101,12 +101,6 @@
 # v0.8.4
 
 ## Tickets
-
-## Other branches merged in this release
-
-# v0.8.4
-
-## Tickets
 * i979: Push docker images to docker hub
 
 ## Other branches merged in this release

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -104,3 +104,10 @@
 
 ## Other branches merged in this release
 
+# v0.8.4
+
+## Tickets
+* i979: Push docker images to docker hub
+
+## Other branches merged in this release
+

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -98,3 +98,9 @@
 * fix
 * stochasticparams
 
+# v0.8.4
+
+## Tickets
+
+## Other branches merged in this release
+

--- a/ReleaseProcess.md
+++ b/ReleaseProcess.md
@@ -12,5 +12,9 @@
 4. [Connect to the UAT machine and deploy there](staging/README.md)
 5. You may go through multiple rounds of steps 1-3 until you have a release
    you are happy to deploy to production.
-6. Deploy to live. (Do we have documentation for this?)
+6. Deploy to live:
+   1. ssh production.montagu.dide.ic.ac.uk
+   1. sudo su
+   1. cd /montagu/deploy
+   1. ./deploy.sh
 7. Use RELEASE_LOG.md to know which tickets to update to the 'Deployed' status

--- a/docker-compose-annex.yml
+++ b/docker-compose-annex.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db_annex:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-db:${MONTAGU_DB_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}
     ports:
       - "15432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   api:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-api:${MONTAGU_API_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-api:${MONTAGU_API_VERSION}
     depends_on:
       - db
     volumes:
@@ -9,32 +9,32 @@ services:
       # volume will remain empty. Otherwise emails are written to disk here.
       - emails:/tmp/montagu_emails
   reporting_api:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-reporting-api:${MONTAGU_REPORTING_API_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-reporting-api:${MONTAGU_REPORTING_API_VERSION}
     volumes:
       - orderly_volume:/orderly
     depends_on:
       - orderly
   db:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-db:${MONTAGU_DB_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}
     ports:
       - "5432:5432"
     volumes:
       - db_volume:/pgdata
   contrib:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-contrib-portal:${MONTAGU_CONTRIB_PORTAL_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-contrib-portal:${MONTAGU_CONTRIB_PORTAL_VERSION}
     depends_on:
       - api
   admin:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-admin-portal:${MONTAGU_ADMIN_PORTAL_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-admin-portal:${MONTAGU_ADMIN_PORTAL_VERSION}
     depends_on:
       - api
   report:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-report-portal:${MONTAGU_REPORT_PORTAL_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-report-portal:${MONTAGU_REPORT_PORTAL_VERSION}
     depends_on:
       - api
       - reporting_api
   proxy:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-reverse-proxy:${MONTAGU_PROXY_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-reverse-proxy:${MONTAGU_PROXY_VERSION}
     ports:
       - "${MONTAGU_PORT}:${MONTAGU_PORT}"
       - 80:80
@@ -46,7 +46,7 @@ services:
       - report
     command: ${MONTAGU_PORT} ${MONTAGU_HOSTNAME}
   orderly:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-orderly:${MONTAGU_ORDERLY_VERSION}
+    image: ${MONTAGU_REGISTRY}/montagu-orderly:${MONTAGU_ORDERLY_VERSION}
     volumes:
       - orderly_volume:/orderly
     command: --port 8321 --go-signal /orderly_go /orderly

--- a/scripts/release/helpers.py
+++ b/scripts/release/helpers.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 import shlex
 
@@ -7,3 +8,23 @@ def run(cmd, working_dir=None):
     result = subprocess.run(parts, check=True, stdout=subprocess.PIPE,
                             universal_newlines=True, cwd=working_dir)
     return result.stdout.strip()
+
+release_tag_pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:-RC(\d+))?$")
+
+def get_latest_release_tag():
+    tags = run("git tag").split('\n')
+    release_tags = sorted(t for t in tags if release_tag_pattern.match(t))
+    return release_tags[-1]
+
+def validate_release_tag(tag):
+    m = release_tag_pattern.match(tag)
+    if not m:
+        raise Exception("Tag {} does not correspond to pattern".format(tag))
+    return m
+
+def parse_version(tag):
+    v = validate_release_tag(tag).groups()
+    return [int(el) for el in v[:3]] + [float(v[3]) if v[3] else float("inf")]
+
+def version_greater_than(target, than):
+    return parse_version(target) > parse_version(than)

--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -11,22 +11,12 @@ Options:
   --test-run    Don't insist on Git being in a clean state
 """
 
-import re
-
 from io import StringIO
 
 from docopt import docopt
 
-from helpers import run
+from helpers import run, get_latest_release_tag, version_greater_than
 from tickets import check_tickets
-
-release_tag_pattern = re.compile(r"^v\d\.\d\.\d(-RC\d)?$")
-
-
-def get_latest_release_tag():
-    tags = run("git tag").split('\n')
-    release_tags = sorted(t for t in tags if release_tag_pattern.match(t))
-    return release_tags[-1]
 
 
 def git_is_clean():
@@ -39,14 +29,11 @@ def tag(tag_name, branch_diff):
     run("git tag -a {tag} -m \"{msg}\"".format(tag=tag_name, msg=message))
 
 
-def get_new_tag():
+def get_new_tag(latest_tag):
     new_tag = "v" + input("What should the new release tag be? v")
-    if new_tag <= latest_tag:
+    if not version_greater_than(new_tag, latest_tag):
         template = "Error: {new_tag} is not after {latest_tag}"
         print(template.format(new_tag=new_tag, latest_tag=latest_tag))
-        exit(-1)
-    if not release_tag_pattern.match(new_tag):
-        print("Error: tag does not correspond to regex")
         exit(-1)
     return new_tag
 
@@ -99,7 +86,7 @@ if __name__ == "__main__":
         print("The latest release was " + latest_tag)
 
         branches_and_tickets = check_tickets(latest_tag)
-        new_tag = get_new_tag()
+        new_tag = get_new_tag(latest_tag)
 
         print("Writing release log...")
         release_message = make_release_message(new_tag, branches_and_tickets)
@@ -107,9 +94,10 @@ if __name__ == "__main__":
         commit_tag_and_push()
 
         print("""Done"
-No changes have been pushed, so please review and then push using 
+No changes have been pushed, so please review and then push using
 
-git push --follow-tags
+  git push --follow-tags
+  ./scripts/release/tag-images.py tag --publish latest
 
 When you come to deploy this release, the RELEASE_LOG.md file
 (or the commit message) will tell you which tickets need to be updated""")

--- a/scripts/release/tag-images.py
+++ b/scripts/release/tag-images.py
@@ -46,7 +46,7 @@ def set_image_tags(version):
     print("Setting image tags")
     for name in container_repo_map.keys():
         print("  - " + name)
-        set_image_tag(km, version)
+        set_image_tag(name, version)
 
 def publish_images(version):
     d = docker.client.from_env()

--- a/scripts/release/tag-images.py
+++ b/scripts/release/tag-images.py
@@ -5,7 +5,7 @@ run with the "publish" option it will also publish images to
 https://hub.docker.com/u/vimc
 
 Usage:
-  tag-images.py tag <version>
+  tag-images.py tag [--publish] <version>
   tag-images.py publish <version>
 """
 import docker
@@ -74,5 +74,7 @@ if __name__ == "__main__":
         raise Exception("Invalid tag")
     if args["tag"]:
         set_image_tags(version)
+        if args["--publish"]:
+            publish_images(version)
     elif args["publish"]:
         publish_images(version)

--- a/scripts/release/tag-images.py
+++ b/scripts/release/tag-images.py
@@ -15,9 +15,6 @@ import os
 import re
 import git_helpers
 
-os.chdir("../..")
-tag = "v0.8.0"
-
 # This feels like something we should have elsewhere; it's a map of
 # the name of the *repo* (the key here) with the name of the submodule
 # *subdirectory* (the value, which then maps onto the docker compose

--- a/scripts/release/tag-images.py
+++ b/scripts/release/tag-images.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Tags images used in a particular release and pushes the tags into
+our local docker registrty at docker.montagu.dide.ic.ac.uk:5000.  If
+run with the "publish" option it will also publish images to
+https://hub.docker.com/u/vimc
+
+Usage:
+  tag-images.py tag <version>
+  tag-images.py publish <version>
+"""
+import docker
+import docopt
+from subprocess import run
+import os
+import re
+import git_helpers
+
+os.chdir("../..")
+tag = "v0.8.0"
+
+# This feels like something we should have elsewhere; it's a map of
+# the name of the *repo* (the key here) with the name of the submodule
+# *subdirectory* (the value, which then maps onto the docker compose
+# container name).  It's easy enough to lift this out later though
+container_repo_map = {
+    "montagu-api": "api",
+    "montagu-reporting-api": "reporting-api",
+    "montagu-db": "db",
+    "montagu-contrib-portal": "contrib-portal",
+    "montagu-admin-portal": "admin-portal",
+    "montagu-report-portal": "report-portal",
+    "montagu-reverse-proxy": "proxy",
+    "montagu-orderly": "orderly"
+}
+
+registry = "docker.montagu.dide.ic.ac.uk:5000"
+
+def set_image_tag(name, version):
+    repo_name = container_repo_map[name]
+    sha = git_helpers.get_past_submodule_version(repo_name, version)
+    d = docker.client.from_env()
+    img = d.images.pull("{}/{}:{}".format(registry, name, sha))
+    tag_and_push(img, registry, name, version)
+
+def set_image_tags(version):
+    print("Setting image tags")
+    for name in container_repo_map.keys():
+        print("  - " + name)
+        set_image_tag(km, version)
+
+def publish_images(version):
+    d = docker.client.from_env()
+    print("Pushing release to docker hub")
+    for name in container_repo_map.keys():
+        img = d.images.get("{}/{}:{}".format(registry, name, version))
+        tag_and_push(img, "vimc", name, version)
+
+# NOTE: Using subprocess here and not the python docker module because
+# the latter does not support streaming as nicely as the CLI
+def tag_and_push(img, registry, name, tag):
+    repo = "{}/{}".format(registry, name)
+    img.tag(repo, tag)
+    run(["docker", "push", "{}:{}".format(repo, tag)], check = True)
+
+def get_past_submodule_versions(master_repo_version):
+    return {k: get_past_submodule_version(k, master_repo_version)
+            for k in os.listdir("submodules")}
+
+if __name__ == "__main__":
+    args = docopt.docopt(__doc__)
+    version = args["<version>"]
+    release_tag_pattern = re.compile(r"^v\d+\.\d+\.\d+(-RC\d)?$")
+    if not release_tag_pattern.match(version):
+        raise Exception("Invalid tag")
+    if args["tag"]:
+        set_image_tags(version)
+    elif args["publish"]:
+        publish_images(version)

--- a/scripts/release/tag-images.py
+++ b/scripts/release/tag-images.py
@@ -18,16 +18,23 @@ import git_helpers
 # This feels like something we should have elsewhere; it's a map of
 # the name of the *repo* (the key here) with the name of the submodule
 # *subdirectory* (the value, which then maps onto the docker compose
-# container name).  It's easy enough to lift this out later though
+# container name).  It's easy enough to lift this out later though.
+#
+# Not currently included are montagu-portal-integration-tests and
+# montagu-api-blackbox-tests (both of which version against the api
+# submodule).
 container_repo_map = {
-    "montagu-api": "api",
-    "montagu-reporting-api": "reporting-api",
-    "montagu-db": "db",
-    "montagu-contrib-portal": "contrib-portal",
     "montagu-admin-portal": "admin-portal",
+    "montagu-api": "api",
+    "montagu-cert-tool": "cert-tool",
+    "montagu-cli": "api",
+    "montagu-contrib-portal": "contrib-portal",
+    "montagu-db": "db",
+    "montagu-migrate": "db",
+    "montagu-orderly": "orderly",
     "montagu-report-portal": "report-portal",
-    "montagu-reverse-proxy": "proxy",
-    "montagu-orderly": "orderly"
+    "montagu-reporting-api": "reporting-api",
+    "montagu-reverse-proxy": "proxy"
 }
 
 registry = "docker.montagu.dide.ic.ac.uk:5000"

--- a/scripts/release/tag-images.py
+++ b/scripts/release/tag-images.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Tags images used in a particular release and pushes the tags into
-our local docker registrty at docker.montagu.dide.ic.ac.uk:5000.  If
-run with the "publish" option it will also publish images to
+our local docker registry at docker.montagu.dide.ic.ac.uk:5000.  Use
+tag 'latest' to select the most recent conforming git tag (this will
+not set things to be the docker 'latest' tag though).  If run with the
+"publish" option it will also publish images to
 https://hub.docker.com/u/vimc
 
 Usage:
   tag-images.py tag [--publish] <version>
   tag-images.py publish <version>
+
 """
 import docker
 import docopt
@@ -14,6 +17,7 @@ from subprocess import run
 import os
 import re
 import git_helpers
+from helpers import get_latest_release_tag, validate_release_tag
 
 # This feels like something we should have elsewhere; it's a map of
 # the name of the *repo* (the key here) with the name of the submodule
@@ -73,9 +77,10 @@ def get_past_submodule_versions(master_repo_version):
 if __name__ == "__main__":
     args = docopt.docopt(__doc__)
     version = args["<version>"]
-    release_tag_pattern = re.compile(r"^v\d+\.\d+\.\d+(-RC\d)?$")
-    if not release_tag_pattern.match(version):
-        raise Exception("Invalid tag")
+    if version == "latest":
+        version = get_latest_release_tag()
+    else:
+        validate_release_tag(version)
     if args["tag"]:
         set_image_tags(version)
         if args["--publish"]:

--- a/src/compose.py
+++ b/src/compose.py
@@ -1,4 +1,5 @@
 from subprocess import Popen
+from docker_helpers import montagu_registry
 
 import versions
 
@@ -37,6 +38,8 @@ def run(args, port, hostname, use_fake_db_annex):
 
 def get_env(port, hostname):
     return {
+        'MONTAGU_REGISTRY': montagu_registry,
+
         'MONTAGU_PORT': str(port),
         'MONTAGU_HOSTNAME': hostname,
 

--- a/src/docker_helpers.py
+++ b/src/docker_helpers.py
@@ -4,7 +4,8 @@ import os
 montagu_registry_local = "docker.montagu.dide.ic.ac.uk:5000"
 montagu_registry_hub = "vimc"
 
-# This is really ugly, but we need to
+# This is really ugly, but the alternative is to alter every call to
+# get_image_name and that feels much more invasive right now.
 try:
     use_docker_hub = os.environ['MONTAGU_USE_DOCKER_HUB'] == "true"
 except KeyError:

--- a/src/docker_helpers.py
+++ b/src/docker_helpers.py
@@ -1,10 +1,19 @@
 from subprocess import check_output, run
+import os
 
-registry_url = "docker.montagu.dide.ic.ac.uk:5000"
+montagu_registry_local = "docker.montagu.dide.ic.ac.uk:5000"
+montagu_registry_hub = "vimc"
 
+# This is really ugly, but we need to
+try:
+    use_docker_hub = os.environ['MONTAGU_USE_DOCKER_HUB'] == "true"
+except KeyError:
+    use_docker_hub = False
+
+montagu_registry = montagu_registry_hub if use_docker_hub else montagu_registry_local
 
 def get_image_name(name, version):
-    return "{url}/{name}:{version}".format(url=registry_url, name=name, version=version)
+    return "{url}/{name}:{version}".format(url=montagu_registry, name=name, version=version)
 
 
 def docker_cp(src, container, target_path):


### PR DESCRIPTION
This PR does a couple of related things:

* `scripts/release/tag-images.py` coordinates tagging images that were used as part of a release and publishing those onto docker hub
* changes to allow deployment using these issues (this removes almost all of our `docker.montagu.dide.ic.ac.uk:5000` strings throughout the code

The idea is we'll have all images that were part of a release lodged on docker hub, tagged with both version numbers and with the git sha.  Eventually we might want to allow using the versioned tags in deployment too (rather than the sha).

In order to push to docker hub you will need to make an account and then have me add you to the vimc account. Anyone can pull the images.

Commit 19eb21d4102049c62ae3bc6392ed8a1b11458d4a introduces changes to the way that the release script handles version numbers - the log entry for that commit details most of this - @MartinEden please check this work in particular.

To try a release from docker hub do

```
MONTAGU_USE_DOCKER_HUB=true ./src/deploy.py
```

(see the comments in src/docker_helpers.py about why this particular bit of ugliness seems like the least-pain way to put this together right now and hopefully we can come up with something better)