### PR TITLE
i1097

### DIFF
--- a/scripts/git_push.sh
+++ b/scripts/git_push.sh
@@ -25,6 +25,7 @@ function cleanup {
 trap cleanup EXIT
 
 vault read -field=value secret/vimc-robot/id_rsa > $SSH_KEY
+chmod 600 $SSH_KEY
 
 export GIT_SSH_COMMAND="ssh -i $SSH_KEY"
 git -C $MONTAGU_PATH push $*

--- a/scripts/git_push.sh
+++ b/scripts/git_push.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -ex
+SCRIPT=$0
+MONTAGU_PATH=$(git -C $(dirname $SCRIPT) rev-parse --show-toplevel)
+
+export VAULT_ADDR='https://support.montagu.dide.ic.ac.uk:8200'
+if [ ! -f ~/.vault-token ]; then
+    if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
+        echo -n "Please provide your GitHub token for the vault: "
+        read -s token
+        echo ""
+        export VAULT_AUTH_GITHUB_TOKEN=${token}
+    fi
+    env | grep -E '^(VAULT_ADDR|VAULT_AUTH_GITHUB_TOKEN)' > shared/vault_config
+    echo "Authenticating with vault"
+    vault auth -method=github
+fi
+
+SSH_PATH=`mktemp -d`
+SSH_KEY="$SSH_PATH/id_rsa"
+
+function cleanup {
+    rm -rf $SSH_PATH
+}
+trap cleanup EXIT
+
+vault read -field=value secret/vimc-robot/id_rsa > $SSH_KEY
+
+export GIT_SSH_COMMAND="ssh -i $SSH_KEY"
+git -C $MONTAGU_PATH push $*

--- a/scripts/setup_git.sh
+++ b/scripts/setup_git.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+set -e
 SCRIPT=$0
 MONTAGU_PATH=$(git -C $(dirname $SCRIPT) rev-parse --show-toplevel)
 
 ## NOTE: this is *not* Rich's email but one associated with our robot
 ## account https://github.com/vimc-robot
+echo "Setting git username and password for $MONTAGU_PATH"
 git -C $MONTAGU_PATH config user.email "rich.fitzjohn+vimc@gmail.com"
 git -C $MONTAGU_PATH config user.name "vimc-robot"
+echo "Done"

--- a/scripts/setup_git.sh
+++ b/scripts/setup_git.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+SCRIPT=$0
+MONTAGU_PATH=$(git -C $(dirname $SCRIPT) rev-parse --show-toplevel)
+
+## NOTE: this is *not* Rich's email but one associated with our robot
+## account https://github.com/vimc-robot
+git -C $MONTAGU_PATH config user.email "rich.fitzjohn+vimc@gmail.com"
+git -C $MONTAGU_PATH config user.name "vimc-robot"


### PR DESCRIPTION
Implements support for using our robot account to create commits on foreign machines

There are two parts needed here.  To create a commit with sensible username and email (which github uses to link to an account) we need to set up the git config.  The `scripts/setup_git.sh` file does this.  It needs running just once during provisioning (after cloning the montagu repo) and sets the configuration just for that repo.

The other part is `scripts/git_push.sh` which fetches the robot's credentials from the vault and organises sets up git to use them.  The credentials are unpacked into a securely created temporary dir and removed on exit (successful or not).  All arguments to git push (e.g., `-u origin <branchname>`) are passed through.

The hope is these will help as we move to continuous deployment by reducing faffing about with credentials etc