### PR TITLE
i1096 - fix db restore without redeploy on science

### DIFF
--- a/src/restore_db.py
+++ b/src/restore_db.py
@@ -1,19 +1,34 @@
 #!/usr/bin/env python3
 
-import database
 import backup
+import database
+from notify import Notifier
 from service import service
 from settings import get_settings
 from os.path import abspath, dirname
 from os import chdir
+from cli import add_test_user
 
 def restore_db():
-    ok = service.status == 'running' and service.volume_present
-    if not ok:
-        raise Exception('montagu not in a state we can restore')
     settings = get_settings(False)
-    backup.restore(settings)
-    database.setup(settings["password_group"])
+    notifier = Notifier(settings['notify_channel'])
+    try:
+        ok = service.status == 'running' and service.volume_present
+        if not ok:
+            raise Exception('montagu not in a state we can restore')
+        backup.restore(settings)
+        database.setup(settings)
+        if settings["add_test_user"] is True:
+            add_test_user()
+        notifier.post("*Restored* data from backup on `{}` :recycle:".format(
+            settings['instance_name']))
+    except Exception as e:
+        print(e)
+        try:
+            notifier.post("*Failed* to restore data on `{}` :bomb:",
+                          settings['instance_name'])
+        except:
+            raise
 
 if __name__ == "__main__":
     abspath = abspath(__file__)

--- a/src/versions.py
+++ b/src/versions.py
@@ -1,10 +1,12 @@
 import re
 from os.path import join
+from pathlib import Path
 from subprocess import run, PIPE
 
+montagu_root = str(Path(__file__).parent.parent)
 
 def get_submodule_version(path):
-    full_path = join("submodules", path)
+    full_path = join(montagu_root, "submodules", path)
     result = run(["git", "-C", full_path, "rev-parse", "--short=7", "HEAD"],
                  stdout=PIPE, check=True, universal_newlines=True)
     return result.stdout.strip()


### PR DESCRIPTION
We will *eventually* get this running as a cron job.

The changes in versions.py make things a little less sensitive to working directories.  The other changes are mostly about getting the notifier working and creating test users if required