### PR TITLE
I1092 - bug with branches that fail issue lookup

### DIFF
--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -140,3 +140,32 @@
 
 ## Other branches merged in this release
 
+# v0.8.5
+
+## Tickets
+* i1044_repository: Record set type when creating a new burden estimate set
+* i1067: Fix restore with annex
+* i1080: Find all instances of 'deterministic' and change to 'central' 
+* i1082: Add model_run_parameter_set to burden_estimate_set
+* i1083: Bug - run-development-apis.sh fails
+* i1084: Embed guidance within Montagu contribution portal
+* i1088: Bug: burden estimates uploading errors on UAT
+* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
+* i1090: model run parameter creation endpoint to accept model version and responsibility set
+* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
+* i1092: Can't make release if branch without issue is merged in
+* i1093: Largest burden estimate uploads time out on UAT
+* i1094: add cases_crs and deaths_crs to database
+* i915: Stream posted burden estimate data from request stream through to database
+* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
+* i919_templates: Add new 96 country templates to portal
+* i942_controller: Create endpoint to retrieve model run parameter sets
+* i942_db: Create endpoint to retrieve model run parameter sets
+* i942_spec: Create endpoint to retrieve model run parameter sets
+* i978: Display name is not rendered in title on report page
+* i979: Push docker images to docker hub
+
+## Other branches merged in this release
+* 1083
+* i1915_update_assertj
+

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -140,3 +140,32 @@
 
 ## Other branches merged in this release
 
+# v0.8.5
+
+## Tickets
+* 1083: No ticket found
+* i1044_repository: Record set type when creating a new burden estimate set
+* i1067: Fix restore with annex
+* i1080: Find all instances of 'deterministic' and change to 'central' 
+* i1082: Add model_run_parameter_set to burden_estimate_set
+* i1083: Bug - run-development-apis.sh fails
+* i1084: Embed guidance within Montagu contribution portal
+* i1088: Bug: burden estimates uploading errors on UAT
+* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
+* i1090: model run parameter creation endpoint to accept model version and responsibility set
+* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
+* i1092: Can't make release if branch without issue is merged in
+* i1093: Largest burden estimate uploads time out on UAT
+* i1094: add cases_crs and deaths_crs to database
+* i1915_update_assertj: No ticket found
+* i915: Stream posted burden estimate data from request stream through to database
+* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
+* i919_templates: Add new 96 country templates to portal
+* i942_controller: Create endpoint to retrieve model run parameter sets
+* i942_db: Create endpoint to retrieve model run parameter sets
+* i942_spec: Create endpoint to retrieve model run parameter sets
+* i978: Display name is not rendered in title on report page
+* i979: Push docker images to docker hub
+
+## Other branches merged in this release
+

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -138,4 +138,32 @@
 ## Tickets
 * i979: Push docker images to docker hub
 
+## Other branches merged in this release# v0.8.5
+
+## Tickets
+* i1044_repository: Record set type when creating a new burden estimate set
+* i1067: Fix restore with annex
+* i1080: Find all instances of 'deterministic' and change to 'central' 
+* i1082: Add model_run_parameter_set to burden_estimate_set
+* i1083: Bug - run-development-apis.sh fails
+* i1084: Embed guidance within Montagu contribution portal
+* i1088: Bug: burden estimates uploading errors on UAT
+* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
+* i1090: model run parameter creation endpoint to accept model version and responsibility set
+* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
+* i1092: Can't make release if branch without issue is merged in
+* i1093: Largest burden estimate uploads time out on UAT
+* i1094: add cases_crs and deaths_crs to database
+* i1915_update_assertj: No ticket found
+* i915: Stream posted burden estimate data from request stream through to database
+* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
+* i919_templates: Add new 96 country templates to portal
+* i942_controller: Create endpoint to retrieve model run parameter sets
+* i942_db: Create endpoint to retrieve model run parameter sets
+* i942_spec: Create endpoint to retrieve model run parameter sets
+* i978: Display name is not rendered in title on report page
+* i979: Push docker images to docker hub
+
 ## Other branches merged in this release
+* 1083
+

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -169,3 +169,9 @@
 * 1083
 * i1915_update_assertj
 
+# v0.8.6
+
+## Tickets
+
+## Other branches merged in this release
+

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -137,31 +137,5 @@
 
 ## Tickets
 * i979: Push docker images to docker hub
-# v0.8.5
-
-## Tickets
-* i1044_repository: Record set type when creating a new burden estimate set
-* i1067: Fix restore with annex
-* i1080: Find all instances of 'deterministic' and change to 'central' 
-* i1082: Add model_run_parameter_set to burden_estimate_set
-* i1083: Bug - run-development-apis.sh fails
-* i1084: Embed guidance within Montagu contribution portal
-* i1088: Bug: burden estimates uploading errors on UAT
-* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
-* i1090: model run parameter creation endpoint to accept model version and responsibility set
-* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
-* i1093: Largest burden estimate uploads time out on UAT
-* i1094: add cases_crs and deaths_crs to database
-* i1915_update_assertj: No ticket found
-* i915: Stream posted burden estimate data from request stream through to database
-* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
-* i919_templates: Add new 96 country templates to portal
-* i942_controller: Create endpoint to retrieve model run parameter sets
-* i942_db: Create endpoint to retrieve model run parameter sets
-* i942_spec: Create endpoint to retrieve model run parameter sets
-* i978: Display name is not rendered in title on report page
-* i979: Push docker images to docker hub
 
 ## Other branches merged in this release
-* 1083
-

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -140,32 +140,3 @@
 
 ## Other branches merged in this release
 
-# v0.8.5
-
-## Tickets
-* 1083: No ticket found
-* i1044_repository: Record set type when creating a new burden estimate set
-* i1067: Fix restore with annex
-* i1080: Find all instances of 'deterministic' and change to 'central' 
-* i1082: Add model_run_parameter_set to burden_estimate_set
-* i1083: Bug - run-development-apis.sh fails
-* i1084: Embed guidance within Montagu contribution portal
-* i1088: Bug: burden estimates uploading errors on UAT
-* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
-* i1090: model run parameter creation endpoint to accept model version and responsibility set
-* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
-* i1092: Can't make release if branch without issue is merged in
-* i1093: Largest burden estimate uploads time out on UAT
-* i1094: add cases_crs and deaths_crs to database
-* i1915_update_assertj: No ticket found
-* i915: Stream posted burden estimate data from request stream through to database
-* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
-* i919_templates: Add new 96 country templates to portal
-* i942_controller: Create endpoint to retrieve model run parameter sets
-* i942_db: Create endpoint to retrieve model run parameter sets
-* i942_spec: Create endpoint to retrieve model run parameter sets
-* i978: Display name is not rendered in title on report page
-* i979: Push docker images to docker hub
-
-## Other branches merged in this release
-

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -140,33 +140,3 @@
 
 ## Other branches merged in this release
 
-
-# v0.8.5
-
-## Tickets
-* i1044_repository: Record set type when creating a new burden estimate set
-* i1067: Fix restore with annex
-* i1080: Find all instances of 'deterministic' and change to 'central' 
-* i1082: Add model_run_parameter_set to burden_estimate_set
-* i1083: Bug - run-development-apis.sh fails
-* i1084: Embed guidance within Montagu contribution portal
-* i1088: Bug: burden estimates uploading errors on UAT
-* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
-* i1090: model run parameter creation endpoint to accept model version and responsibility set
-* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
-* i1092: Can't make release if branch without issue is merged in
-* i1093: Largest burden estimate uploads time out on UAT
-* i1094: add cases_crs and deaths_crs to database
-* i915: Stream posted burden estimate data from request stream through to database
-* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
-* i919_templates: Add new 96 country templates to portal
-* i942_controller: Create endpoint to retrieve model run parameter sets
-* i942_db: Create endpoint to retrieve model run parameter sets
-* i942_spec: Create endpoint to retrieve model run parameter sets
-* i978: Display name is not rendered in title on report page
-* i979: Push docker images to docker hub
-
-## Other branches merged in this release
-* 1083
-* i1915_update_assertj
-

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -138,32 +138,5 @@
 ## Tickets
 * i979: Push docker images to docker hub
 
-## Other branches merged in this release# v0.8.5
-
-## Tickets
-* i1044_repository: Record set type when creating a new burden estimate set
-* i1067: Fix restore with annex
-* i1080: Find all instances of 'deterministic' and change to 'central' 
-* i1082: Add model_run_parameter_set to burden_estimate_set
-* i1083: Bug - run-development-apis.sh fails
-* i1084: Embed guidance within Montagu contribution portal
-* i1088: Bug: burden estimates uploading errors on UAT
-* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
-* i1090: model run parameter creation endpoint to accept model version and responsibility set
-* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
-* i1092: Can't make release if branch without issue is merged in
-* i1093: Largest burden estimate uploads time out on UAT
-* i1094: add cases_crs and deaths_crs to database
-* i1915_update_assertj: No ticket found
-* i915: Stream posted burden estimate data from request stream through to database
-* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
-* i919_templates: Add new 96 country templates to portal
-* i942_controller: Create endpoint to retrieve model run parameter sets
-* i942_db: Create endpoint to retrieve model run parameter sets
-* i942_spec: Create endpoint to retrieve model run parameter sets
-* i978: Display name is not rendered in title on report page
-* i979: Push docker images to docker hub
-
 ## Other branches merged in this release
-* 1083
 

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -140,3 +140,32 @@
 
 ## Other branches merged in this release
 
+# v0.8.5
+
+## Tickets
+* i1044_repository: Record set type when creating a new burden estimate set
+* i1067: Fix restore with annex
+* i1080: Find all instances of 'deterministic' and change to 'central' 
+* i1082: Add model_run_parameter_set to burden_estimate_set
+* i1083: Bug - run-development-apis.sh fails
+* i1084: Embed guidance within Montagu contribution portal
+* i1088: Bug: burden estimates uploading errors on UAT
+* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
+* i1090: model run parameter creation endpoint to accept model version and responsibility set
+* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
+* i1092: Can't make release if branch without issue is merged in
+* i1093: Largest burden estimate uploads time out on UAT
+* i1094: add cases_crs and deaths_crs to database
+* i1915_update_assertj: No ticket found
+* i915: Stream posted burden estimate data from request stream through to database
+* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
+* i919_templates: Add new 96 country templates to portal
+* i942_controller: Create endpoint to retrieve model run parameter sets
+* i942_db: Create endpoint to retrieve model run parameter sets
+* i942_spec: Create endpoint to retrieve model run parameter sets
+* i978: Display name is not rendered in title on report page
+* i979: Push docker images to docker hub
+
+## Other branches merged in this release
+* 1083
+

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -137,3 +137,31 @@
 
 ## Tickets
 * i979: Push docker images to docker hub
+# v0.8.5
+
+## Tickets
+* i1044_repository: Record set type when creating a new burden estimate set
+* i1067: Fix restore with annex
+* i1080: Find all instances of 'deterministic' and change to 'central' 
+* i1082: Add model_run_parameter_set to burden_estimate_set
+* i1083: Bug - run-development-apis.sh fails
+* i1084: Embed guidance within Montagu contribution portal
+* i1088: Bug: burden estimates uploading errors on UAT
+* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
+* i1090: model run parameter creation endpoint to accept model version and responsibility set
+* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
+* i1093: Largest burden estimate uploads time out on UAT
+* i1094: add cases_crs and deaths_crs to database
+* i1915_update_assertj: No ticket found
+* i915: Stream posted burden estimate data from request stream through to database
+* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
+* i919_templates: Add new 96 country templates to portal
+* i942_controller: Create endpoint to retrieve model run parameter sets
+* i942_db: Create endpoint to retrieve model run parameter sets
+* i942_spec: Create endpoint to retrieve model run parameter sets
+* i978: Display name is not rendered in title on report page
+* i979: Push docker images to docker hub
+
+## Other branches merged in this release
+* 1083
+

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -140,32 +140,3 @@
 
 ## Other branches merged in this release
 
-# v0.8.5
-
-## Tickets
-* i1044_repository: Record set type when creating a new burden estimate set
-* i1067: Fix restore with annex
-* i1080: Find all instances of 'deterministic' and change to 'central' 
-* i1082: Add model_run_parameter_set to burden_estimate_set
-* i1083: Bug - run-development-apis.sh fails
-* i1084: Embed guidance within Montagu contribution portal
-* i1088: Bug: burden estimates uploading errors on UAT
-* i1088_refactor_error_handler: Bug: burden estimates uploading errors on UAT
-* i1090: model run parameter creation endpoint to accept model version and responsibility set
-* i1091: Add help pages with Demographic data FAQs and link them from responsibility model outputs help page
-* i1092: Can't make release if branch without issue is merged in
-* i1093: Largest burden estimate uploads time out on UAT
-* i1094: add cases_crs and deaths_crs to database
-* i1915_update_assertj: No ticket found
-* i915: Stream posted burden estimate data from request stream through to database
-* i915_streamed_copy: Stream posted burden estimate data from request stream through to database
-* i919_templates: Add new 96 country templates to portal
-* i942_controller: Create endpoint to retrieve model run parameter sets
-* i942_db: Create endpoint to retrieve model run parameter sets
-* i942_spec: Create endpoint to retrieve model run parameter sets
-* i978: Display name is not rendered in title on report page
-* i979: Push docker images to docker hub
-
-## Other branches merged in this release
-* 1083
-

--- a/RELEASE_LOG.md
+++ b/RELEASE_LOG.md
@@ -140,6 +140,7 @@
 
 ## Other branches merged in this release
 
+
 # v0.8.5
 
 ## Tickets
@@ -168,10 +169,4 @@
 ## Other branches merged in this release
 * 1083
 * i1915_update_assertj
-
-# v0.8.6
-
-## Tickets
-
-## Other branches merged in this release
 

--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -17,6 +17,7 @@ from docopt import docopt
 
 from helpers import run, get_latest_release_tag, version_greater_than
 from tickets import check_tickets
+from tickets import NOT_FOUND
 
 
 def git_is_clean():
@@ -44,7 +45,12 @@ def make_release_message(tag, branches_and_tickets):
         print("", file=msg)
         print("## Tickets", file=msg)
         for branch, ticket in branches_and_tickets:
-            if ticket:
+            if ticket == NOT_FOUND:
+                summary = "No ticket found"
+                line = "* {branch}: {summary}".format(branch=branch,
+                                                      summary=summary)
+                print(line, file=msg)
+            elif ticket:
                 summary = ticket.get("summary")
                 line = "* {branch}: {summary}".format(branch=branch,
                                                       summary=summary)

--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -55,7 +55,6 @@ def make_release_message(tag, branches_and_tickets):
                 line = "* {branch}: {summary}".format(branch=branch,
                                                       summary=summary)
                 print(line, file=msg)
-
         print("\n## Other branches merged in this release", file=msg)
         for branch, ticket in branches_and_tickets:
             if not ticket:

--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -45,7 +45,9 @@ def make_release_message(tag, branches_and_tickets):
         print("", file=msg)
         print("## Tickets", file=msg)
         for branch, ticket in branches_and_tickets:
-            if not ticket == NOT_FOUND:
+            if ticket == NOT_FOUND:
+                pass
+            else:
                 summary = ticket.get("summary")
                 line = "* {branch}: {summary}".format(branch=branch,
                                                       summary=summary)

--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -45,14 +45,14 @@ def make_release_message(tag, branches_and_tickets):
         print("", file=msg)
         print("## Tickets", file=msg)
         for branch, ticket in branches_and_tickets:
-            if ticket and not ticket == NOT_FOUND:
+            if not ticket == NOT_FOUND:
                 summary = ticket.get("summary")
                 line = "* {branch}: {summary}".format(branch=branch,
                                                       summary=summary)
                 print(line, file=msg)
         print("\n## Other branches merged in this release", file=msg)
         for branch, ticket in branches_and_tickets:
-            if not ticket or ticket == NOT_FOUND:
+            if ticket == NOT_FOUND:
                 print("* " + branch, file=msg)
         return msg.getvalue()
 

--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -45,19 +45,14 @@ def make_release_message(tag, branches_and_tickets):
         print("", file=msg)
         print("## Tickets", file=msg)
         for branch, ticket in branches_and_tickets:
-            if ticket == NOT_FOUND:
-                summary = "No ticket found"
-                line = "* {branch}: {summary}".format(branch=branch,
-                                                      summary=summary)
-                print(line, file=msg)
-            elif ticket:
+            if ticket and not ticket == NOT_FOUND:
                 summary = ticket.get("summary")
                 line = "* {branch}: {summary}".format(branch=branch,
                                                       summary=summary)
                 print(line, file=msg)
         print("\n## Other branches merged in this release", file=msg)
         for branch, ticket in branches_and_tickets:
-            if not ticket:
+            if not ticket or ticket == NOT_FOUND:
                 print("* " + branch, file=msg)
         return msg.getvalue()
 

--- a/scripts/release/tickets.py
+++ b/scripts/release/tickets.py
@@ -77,7 +77,7 @@ def check_ticket(branch, ticket):
     problem = False
     print("* " + branch, end="")
     if ticket == NOT_FOUND:
-        print(": Unable to find ticket corresponding to branch " + branch,
+        print("\n  Warning: Unable to find ticket corresponding to branch " + branch,
               end="")
         problem = True
     else:

--- a/scripts/release/tickets.py
+++ b/scripts/release/tickets.py
@@ -52,7 +52,7 @@ class YouTrackHelper:
             if match:
                 yield self.get_ticket(branch, match.group(1))
             else:
-                yield branch, NOT_FOUND
+                yield branch, None
 
     def get_ticket(self, branch, id):
         full_id = "VIMC-" + id
@@ -76,7 +76,7 @@ class YouTrackHelper:
 def check_ticket(branch, ticket):
     problem = False
     print("* " + branch, end="")
-    if ticket == NOT_FOUND:
+    if ticket is None or ticket == NOT_FOUND:
         print(": Unable to find ticket corresponding to branch " + branch,
               end="")
         problem = True

--- a/scripts/release/tickets.py
+++ b/scripts/release/tickets.py
@@ -52,7 +52,7 @@ class YouTrackHelper:
             if match:
                 yield self.get_ticket(branch, match.group(1))
             else:
-                yield branch, None
+                yield branch, NOT_FOUND
 
     def get_ticket(self, branch, id):
         full_id = "VIMC-" + id
@@ -76,7 +76,7 @@ class YouTrackHelper:
 def check_ticket(branch, ticket):
     problem = False
     print("* " + branch, end="")
-    if ticket is None or ticket == NOT_FOUND:
+    if ticket == NOT_FOUND:
         print(": Unable to find ticket corresponding to branch " + branch,
               end="")
         problem = True

--- a/scripts/release/tickets.py
+++ b/scripts/release/tickets.py
@@ -76,9 +76,7 @@ class YouTrackHelper:
 def check_ticket(branch, ticket):
     problem = False
     print("* " + branch, end="")
-    if ticket is None:
-        pass
-    elif ticket == NOT_FOUND:
+    if ticket is None or ticket == NOT_FOUND:
         print(": Unable to find ticket corresponding to branch " + branch,
               end="")
         problem = True


### PR DESCRIPTION
Fixes bug with branches that don't have tickets associated with them.

Simplified logic to treat branches as just one of:
1. a branch that *does* have a ticket associated with it, in which case we use that info in the release log
2. a branch that does *not* have a ticket associated with it, in which case we print a warning to the console,  and if the user continues list it in the 'other branches' section of the release log

i.e. don't bother distinguishing between the cases where a branch matches the regex but fails the issue lookup, and where a branch fails the regex