### PR TITLE
i1139 - support multiple montagu instances on a single host

### DIFF
--- a/docker-compose-annex.yml
+++ b/docker-compose-annex.yml
@@ -3,7 +3,7 @@ services:
   db_annex:
     image: ${MONTAGU_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}
     ports:
-      - "15432:5432"
+      - "${MONTAGU_PORT_ANNEX}:5432"
     volumes:
       - db_annex_volume:/pgdata
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     image: ${MONTAGU_REGISTRY}/montagu-reverse-proxy:${MONTAGU_PROXY_VERSION}
     ports:
       - "${MONTAGU_PORT}:${MONTAGU_PORT}"
-      - 80:80
+      - "${MONTAGU_PORT_HTTP}:80"
     depends_on:
       - api
       - reporting_api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   db:
     image: ${MONTAGU_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}
     ports:
-      - "5432:5432"
+      - "${MONTAGU_PORT_DB}:5432"
     volumes:
       - db_volume:/pgdata
   contrib:

--- a/src/cli.py
+++ b/src/cli.py
@@ -10,6 +10,7 @@ import versions
 from database import user_configs
 from docker_helpers import get_image_name
 from settings import get_settings
+from service import MontaguService
 
 from service_config import api_db_user
 
@@ -46,11 +47,13 @@ def cli():
 
 def add_test_user():
     settings = get_settings(do_first_time_setup=False, quiet=True)
+    service = MontaguService(settings)
+    network = service.network_name
 
     command = [
         "docker", "run",
         "-it",
-        "--network", "montagu_default"
+        "--network", network
     ]
 
     password_group = settings['password_group']

--- a/src/cli.py
+++ b/src/cli.py
@@ -28,7 +28,7 @@ def add_secure_config(password_group):
 
 
 def cli():
-    settings = get_settings(do_first_time_setup=False, quiet=True)
+    settings = get_settings(quiet=True)
 
     command = [
         "docker", "run",
@@ -46,7 +46,7 @@ def cli():
 
 
 def add_test_user():
-    settings = get_settings(do_first_time_setup=False, quiet=True)
+    settings = get_settings(quiet=True)
     service = MontaguService(settings)
     network = service.network_name
 

--- a/src/compose.py
+++ b/src/compose.py
@@ -10,7 +10,7 @@ def start(settings):
 
 def stop(settings):
     command = "down" if settings["persist_data"] else "down --volumes"
-    run(command, port, port_db, hostname, use_fake_db_annex, project_name)
+    run(command, settings)
 
 
 def pull(settings):
@@ -20,7 +20,7 @@ def pull(settings):
 def run(args, settings):
     project_name = settings["docker_prefix"]
     prefix = 'docker-compose --project-name {} '.format(project_name)
-    if use_fake_db_annex:
+    if settings["db_annex_type"] == "fake":
         # NOTE: it's surprising that the '../' is needed here, but
         # docker-compose apparently looks like git through parent
         # directories until it finds a docker-compose file!

--- a/src/compose.py
+++ b/src/compose.py
@@ -5,14 +5,12 @@ import versions
 
 
 def start(port, hostname, use_fake_db_annex, project_name):
-    run("up -d", port, hostname, use_fake_db_annex)
+    run("up -d", port, hostname, use_fake_db_annex, project_name)
 
 
 def stop(port, hostname, persist_volumes, use_fake_db_annex, project_name):
-    if persist_volumes:
-        run("down", port, hostname, use_fake_db_annex)
-    else:
-        run("down --volumes", port, hostname, use_fake_db_annex)  # Also deletes volumes
+    command = "down" if persist_volumes else "down --volumes"
+    run(command, port, hostname, use_fake_db_annex, project_name)
 
 
 def pull(port, hostname, project_name):
@@ -23,7 +21,7 @@ def pull(port, hostname, project_name):
 
 
 def run(args, port, hostname, use_fake_db_annex, project_name):
-    prefix = 'docker-compose --project-name ' + project_name
+    prefix = 'docker-compose --project-name {} '.format(project_name)
     if use_fake_db_annex:
         # NOTE: it's surprising that the '../' is needed here, but
         # docker-compose apparently looks like git through parent

--- a/src/compose.py
+++ b/src/compose.py
@@ -4,23 +4,21 @@ from docker_helpers import montagu_registry
 import versions
 
 
-def start(port, hostname, use_fake_db_annex, project_name):
-    run("up -d", port, hostname, use_fake_db_annex, project_name)
+def start(settings):
+    run("up -d", settings)
 
 
-def stop(port, hostname, persist_volumes, use_fake_db_annex, project_name):
-    command = "down" if persist_volumes else "down --volumes"
-    run(command, port, hostname, use_fake_db_annex, project_name)
+def stop(settings):
+    command = "down" if settings["persist_volumes"] else "down --volumes"
+    run(command, port, port_db, hostname, use_fake_db_annex, project_name)
 
 
-def pull(port, hostname, project_name):
-    # NOTE: passing use_fake_db_annex = False here because it does not
-    # affect the pull (the fake db annex uses the main montagu-db
-    # container)
-    run("pull", port, hostname, False, project_name)
+def pull(settings):
+    run("pull", settings)
 
 
-def run(args, port, hostname, use_fake_db_annex, project_name):
+def run(args, settings):
+    project_name = settings["docker_prefix"]
     prefix = 'docker-compose --project-name {} '.format(project_name)
     if use_fake_db_annex:
         # NOTE: it's surprising that the '../' is needed here, but
@@ -28,18 +26,22 @@ def run(args, port, hostname, use_fake_db_annex, project_name):
         # directories until it finds a docker-compose file!
         prefix += '-f ../docker-compose.yml -f ../docker-compose-annex.yml '
     cmd = prefix + args
-    p = Popen(cmd, env=get_env(port, hostname), shell=True)
+    p = Popen(cmd, env=get_env(settings), shell=True)
     p.wait()
     if p.returncode != 0:
         raise Exception("An error occurred: docker-compose returned {}".format(p.returncode))
 
 
-def get_env(port, hostname):
+def get_env(settings):
+    port = settings["port"]
+    port_db = settings["port_db"]
+    hostname = settings["hostname"]
     return {
         'MONTAGU_REGISTRY': montagu_registry,
 
         'MONTAGU_PORT': str(port),
         'MONTAGU_HOSTNAME': hostname,
+        'MONTAGU_PORT_DB': str(port_db),
 
         'MONTAGU_API_VERSION': versions.api,
         'MONTAGU_REPORTING_API_VERSION': versions.reporting_api,

--- a/src/compose.py
+++ b/src/compose.py
@@ -36,12 +36,14 @@ def get_env(settings):
     port = settings["port"]
     port_db = settings["port_db"]
     hostname = settings["hostname"]
+    port_annex = settings.get("port_annex", "")
     return {
         'MONTAGU_REGISTRY': montagu_registry,
 
         'MONTAGU_PORT': str(port),
         'MONTAGU_HOSTNAME': hostname,
         'MONTAGU_PORT_DB': str(port_db),
+        'MONTAGU_PORT_ANNEX': str(port_annex),
 
         'MONTAGU_API_VERSION': versions.api,
         'MONTAGU_REPORTING_API_VERSION': versions.reporting_api,

--- a/src/compose.py
+++ b/src/compose.py
@@ -4,26 +4,26 @@ from docker_helpers import montagu_registry
 import versions
 
 
-def start(port, hostname, use_fake_db_annex):
+def start(port, hostname, use_fake_db_annex, project_name):
     run("up -d", port, hostname, use_fake_db_annex)
 
 
-def stop(port, hostname, persist_volumes, use_fake_db_annex):
+def stop(port, hostname, persist_volumes, use_fake_db_annex, project_name):
     if persist_volumes:
         run("down", port, hostname, use_fake_db_annex)
     else:
         run("down --volumes", port, hostname, use_fake_db_annex)  # Also deletes volumes
 
 
-def pull(port, hostname):
+def pull(port, hostname, project_name):
     # NOTE: passing use_fake_db_annex = False here because it does not
     # affect the pull (the fake db annex uses the main montagu-db
     # container)
-    run("pull", port, hostname, False)
+    run("pull", port, hostname, False, project_name)
 
 
-def run(args, port, hostname, use_fake_db_annex):
-    prefix = 'docker-compose --project-name montagu '
+def run(args, port, hostname, use_fake_db_annex, project_name):
+    prefix = 'docker-compose --project-name ' + project_name
     if use_fake_db_annex:
         # NOTE: it's surprising that the '../' is needed here, but
         # docker-compose apparently looks like git through parent

--- a/src/compose.py
+++ b/src/compose.py
@@ -9,7 +9,7 @@ def start(settings):
 
 
 def stop(settings):
-    command = "down" if settings["persist_volumes"] else "down --volumes"
+    command = "down" if settings["persist_data"] else "down --volumes"
     run(command, port, port_db, hostname, use_fake_db_annex, project_name)
 
 

--- a/src/compose.py
+++ b/src/compose.py
@@ -34,14 +34,17 @@ def run(args, settings):
 
 def get_env(settings):
     port = settings["port"]
+    port_http = settings["port_http"]
     port_db = settings["port_db"]
     hostname = settings["hostname"]
     port_annex = settings.get("port_annex", "")
     return {
         'MONTAGU_REGISTRY': montagu_registry,
 
-        'MONTAGU_PORT': str(port),
         'MONTAGU_HOSTNAME': hostname,
+
+        'MONTAGU_PORT': str(port),
+        'MONTAGU_PORT_HTTP': str(port_http),
         'MONTAGU_PORT_DB': str(port_db),
         'MONTAGU_PORT_ANNEX': str(port_annex),
 

--- a/src/database.py
+++ b/src/database.py
@@ -7,7 +7,6 @@ import psycopg2
 
 import versions
 from docker_helpers import get_image_name, pull
-from service import service, network_name
 from service_config import api_db_user
 from settings import get_secret
 
@@ -72,7 +71,7 @@ class UserConfig:
             self._password = self.password_source.get()
         return self._password
 
-def set_root_password(password):
+def set_root_password(service, password):
     query = "ALTER USER {user} WITH PASSWORD '{password}'".format(user=root_user, password=password)
     service.db.exec_run('psql -U {user} -d postgres -c "{query}"'.format(user=root_user, query=query))
 
@@ -160,7 +159,8 @@ def set_permissions(db, user):
         template = "Unhandled permission type '{permissions}' for user '{name}'"
         raise Exception(template.format(name=user.name, permissions=user.permissions))
 
-def migrate_schema_core(root_password, annex_settings):
+def migrate_schema_core(service, root_password, annex_settings):
+    network_name = service.network_name
     print("- migrating schema")
     image = get_image_name("montagu-migrate", versions.db)
     pull(image)
@@ -173,7 +173,8 @@ def migrate_schema_core(root_password, annex_settings):
           ["-user=vimc", "-password=" + root_password, "migrate"]
     run(cmd, check=True)
 
-def migrate_schema_annex(annex_settings):
+def migrate_schema_annex(service, annex_settings):
+    network_name = service.network_name
     print("- migrating annex schema")
     image = get_image_name("montagu-migrate", versions.db)
     pull(image)
@@ -249,15 +250,15 @@ def for_each_user(root_password, users, operation):
         conn.commit()
 
 
-def setup(settings):
-    annex_settings = setup_annex(settings)
+def setup(service):
+    annex_settings = setup_annex(service)
 
-    password_group = settings["password_group"]
+    password_group = service.settings["password_group"]
     print("Setting up database users")
     print("- Scrambling root password")
     if password_group is not None:
         root_password = GeneratePassword().get()
-        set_root_password(root_password)
+        set_root_password(service, root_password)
     else:
         root_password = 'changeme'
 
@@ -278,7 +279,7 @@ def setup(settings):
     for_each_user(root_password, users, setup_user)
 
     print("- Migrating database schema")
-    migrate_schema_core(root_password, annex_settings)
+    migrate_schema_core(service, root_password, annex_settings)
 
     print("- Refreshing permissions")
     # The migrations may have added new tables, so we should set the permissions
@@ -291,13 +292,13 @@ def setup(settings):
 
     return passwords
 
-def setup_annex(settings):
+def setup_annex(service):
     print("Setting up annex")
-    annex_settings = get_annex_settings(settings)
+    annex_settings = get_annex_settings(service.settings)
     if annex_settings['migrate']:
         # NOTE: we do this only on production.  This will mean that
         # there are some things that it is hard to test in staging.
-        migrate_schema_annex(annex_settings)
+        migrate_schema_annex(service, annex_settings)
         setup_annex_users(annex_settings)
     return annex_settings
 
@@ -316,7 +317,7 @@ def grant_readonly_annex_root(root_password, annex_settings):
         with conn.cursor() as cur:
             grant_readonly_annex(cur, root, annex_settings)
 
-def prepare_db_for_import(settings):
+def prepare_db_for_import(service):
     print("Preparing databse for import")
     ## NOTE: this could otherwise be done by connecting using the
     ## connection function, but that that requires further changes to
@@ -329,6 +330,6 @@ def prepare_db_for_import(settings):
     db.exec_run(["dropdb", "-U", "vimc", "--if-exists", "montagu"])
     db.exec_run(["createdb", "-U", "vimc", "montagu"])
     print("- configuring users")
-    users = user_configs(settings["password_group"])
+    users = user_configs(service.settings["password_group"])
     for user in users:
         db.exec_run(["createuser", "-U", "vimc", user.name])

--- a/src/database.py
+++ b/src/database.py
@@ -209,7 +209,7 @@ def get_annex_settings(settings):
         host = "db_annex" # docker container name in compose
         port = 5432
         host_from_deploy = "localhost" # from host
-        port_from_deploy = settings["port_db_annex"]
+        port_from_deploy = settings["port_annex"]
         migrate = True
         group = None
     else:

--- a/src/database.py
+++ b/src/database.py
@@ -209,12 +209,12 @@ def get_annex_settings(settings):
         host = "db_annex" # docker container name in compose
         port = 5432
         host_from_deploy = "localhost" # from host
-        port_from_deploy = 15432
+        port_from_deploy = settings["port_db_annex"]
         migrate = True
         group = None
     else:
         host = "annex.montagu.dide.ic.ac.uk" # address of our real server
-        port = 15432
+        port = 15432 # port of our real server
         host_from_deploy = host
         port_from_deploy = port
         migrate = settings["db_annex_type"] == "real"

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -87,7 +87,7 @@ def _deploy():
 
 def configure_montagu(service, is_first_time):
     # Do things to the database
-    data_exists = (not is_first_time) and settings["persist_data"]
+    data_exists = (not is_first_time) and service.settings["persist_data"]
     if data_exists:
         print("Skipping data import: 'persist_data' is set, and this is not a first-time deployment")
     else:

--- a/src/orderly.py
+++ b/src/orderly.py
@@ -15,7 +15,7 @@ def configure_orderly(service, initialise_volume):
     ## clone:
     configure_orderly_ssh(service)
     ## Then this requires an empty directory:
-    if initialise_volume and settings["initial_data_source"] != "restore":
+    if initialise_volume and service.settings["initial_data_source"] != "restore":
         print("Setting up orderly store")
         initialise_orderly_store(service)
     ## Then set up some passwords

--- a/src/orderly.py
+++ b/src/orderly.py
@@ -4,49 +4,44 @@ import os
 import os.path
 import paths
 
-import versions
 from docker_helpers import docker_cp
-from service import orderly_name, orderly_volume_name
-
 from settings import get_secret, save_secret
-from service import orderly_volume_name
-
 from database import VaultPassword
 
 orderly_ssh_keypath = ""
 
-def configure_orderly(initialise_volume, settings):
+def configure_orderly(service, initialise_volume):
     ## Run this one first because we might need to use the ssh keys to
     ## clone:
-    configure_orderly_ssh(settings)
+    configure_orderly_ssh(service)
     ## Then this requires an empty directory:
     if initialise_volume and settings["initial_data_source"] != "restore":
         print("Setting up orderly store")
-        initialise_orderly_store(settings)
+        initialise_orderly_store(service)
     ## Then set up some passwords
-    configure_orderly_envir(settings)
+    configure_orderly_envir(service)
     ## And we're off
     print("Sending orderly go signal")
-    args = ["docker", "exec", orderly_name, "touch", "/orderly_go"]
+    args = ["docker", "exec", service.orderly.name, "touch", "/orderly_go"]
     run(args)
 
-def configure_orderly_envir(settings):
-    envir = orderly_prepare_envir(settings['password_group'])
-    docker_cp(envir, orderly_name, "/orderly")
+def configure_orderly_envir(service):
+    envir = orderly_prepare_envir(service.settings['password_group'])
+    docker_cp(envir, service.orderly.name, "/orderly")
 
-def initialise_orderly_store(settings):
-    if settings['clone_reports']:
+def initialise_orderly_store(service):
+    if service.settings['clone_reports']:
         print("creating orderly store by cloning montagu-reports")
         cmd = ["git", "clone", "git@github.com:vimc/montagu-reports.git",
                "/orderly"]
     else:
         print("creating empty orderly store")
         cmd = ["/usr/bin/orderly_init", "/orderly"]
-    run(["docker", "exec", orderly_name] + cmd, check = True)
+    run(["docker", "exec", service.orderly.name] + cmd, check = True)
 
-def configure_orderly_ssh(settings):
-    needs_ssh = settings['clone_reports'] or \
-                settings['initial_data_source'] == 'restore'
+def configure_orderly_ssh(service):
+    needs_ssh = service.settings['clone_reports'] or \
+                service.settings['initial_data_source'] == 'restore'
     if not needs_ssh:
         return
     ssh = paths.orderly + "/.ssh"
@@ -58,7 +53,7 @@ def configure_orderly_ssh(settings):
         os.chmod(ssh + "/id_rsa", 0o600)
         with open(ssh + "/known_hosts", 'w') as output:
             run(["ssh-keyscan", "github.com"], stdout = output, check = True)
-    docker_cp(ssh, orderly_name, "/root/.ssh")
+    docker_cp(ssh, service.orderly.name, "/root/.ssh")
 
 def orderly_prepare_envir(password_group):
     print("preparing orderly configuration")

--- a/src/restore_db.py
+++ b/src/restore_db.py
@@ -10,7 +10,7 @@ from os import chdir
 from cli import add_test_user
 
 def restore_db():
-    settings = get_settings(False)
+    settings = get_settings()
     service = MontaguService(settings)
     notifier = Notifier(settings['notify_channel'])
     try:

--- a/src/restore_db.py
+++ b/src/restore_db.py
@@ -3,7 +3,7 @@
 import backup
 import database
 from notify import Notifier
-from service import service
+from service import MontaguService
 from settings import get_settings
 from os.path import abspath, dirname
 from os import chdir
@@ -11,13 +11,14 @@ from cli import add_test_user
 
 def restore_db():
     settings = get_settings(False)
+    service = MontaguService(settings)
     notifier = Notifier(settings['notify_channel'])
     try:
-        ok = service.status == 'running' and service.volume_present
+        ok = service.status == 'running' and service.db_volume_present
         if not ok:
             raise Exception('montagu not in a state we can restore')
-        backup.restore(settings)
-        database.setup(settings)
+        backup.restore(service)
+        database.setup(service)
         if settings["add_test_user"] is True:
             add_test_user()
         notifier.post("*Restored* data from backup on `{}` :recycle:".format(

--- a/src/service.py
+++ b/src/service.py
@@ -138,17 +138,12 @@ class MontaguService:
             except:
                 print("Killing orderly container failed - continuing")
                 pass
-        compose.stop(self.settings["port"], self.settings["hostname"],
-                     persist_volumes=self.settings["persist_data"],
-                     use_fake_db_annex=self.use_fake_db_annex,
-                     project_name=self.prefix)
+        compose.stop(self.settings)
 
     def start(self):
         print("Starting Montagu...", flush=True)
-        compose.pull(self.settings["port"], self.settings["hostname"],
-                     self.prefix)
-        compose.start(self.settings["port"], self.settings["hostname"],
-                      self.use_fake_db_annex, self.prefix)
+        compose.pull(self.settings)
+        compose.start(self.settings)
         print("- Checking Montagu has started successfully")
         sleep(2)
         if self.status != "running":

--- a/src/service.py
+++ b/src/service.py
@@ -131,7 +131,9 @@ class MontaguService:
         # see how to work around at the R level. So instead we send an
         # interrupt signal (SIGINT) just before the stop, and that
         # seems to bring things down much more quicky.
-        print("Stopping Montagu...", flush=True)
+        print("Stopping Montagu...({}: {})".format(
+            self.settings["instance_name"], self.settings["docker_prefix"]),
+            flush=True)
         if self.orderly:
             try:
                 self.orderly.kill("SIGINT")

--- a/src/service.py
+++ b/src/service.py
@@ -44,7 +44,7 @@ class MontaguService:
 
     @property
     def container_names(self):
-        return set([self._container_name(x) for x in self.containers.keys()])
+        return set([self.container_name(x) for x in self.containers.keys()])
 
     @property
     def status(self):
@@ -67,8 +67,11 @@ class MontaguService:
             raise Exception("Montagu service is in a indeterminate state. "
                             "Manual intervention is required.\nStatus: {}".format(status_map))
 
-    def _container_name(self, name):
+    def container_name(self, name):
         return "{}_{}_1".format(self.prefix, self.containers[name])
+
+    def volume_name(self, name):
+        return "{}_{}".format(self.prefix, self.volumes[name])
 
     @property
     def api(self):
@@ -105,7 +108,7 @@ class MontaguService:
     @property
     def db_volume_present(self):
         try:
-            self.client.volumes.get(self.db_volume_name)
+            self.client.volumes.get(self.volume_name("db"))
             return True
         except docker.errors.NotFound:
             return False
@@ -114,17 +117,9 @@ class MontaguService:
     def network_name(self):
         return "{}_{}".format(self.prefix, self.network)
 
-    @property
-    def orderly_volume_name(self):
-        return "{}_{}".format(self.prefix, self.volumes["orderly"])
-
-    @property
-    def db_volume_name(self):
-        return "{}_{}".format(self.prefix, self.volumes["db"])
-
     def _get(self, name):
         try:
-            return self.client.containers.get(self._container_name(name))
+            return self.client.containers.get(self.container_name(name))
         except docker.errors.NotFound:
             return None
 

--- a/src/service.py
+++ b/src/service.py
@@ -133,11 +133,15 @@ class MontaguService:
         # seems to bring things down much more quicky.
         print("Stopping Montagu...", flush=True)
         if self.orderly:
-            self.orderly.kill("SIGINT")
+            try:
+                self.orderly.kill("SIGINT")
+            except:
+                print("Killing orderly container failed - continuing")
+                pass
         compose.stop(self.settings["port"], self.settings["hostname"],
                      persist_volumes=self.settings["persist_data"],
                      use_fake_db_annex=self.use_fake_db_annex,
-                     docker_prefix=self.prefix)
+                     project_name=self.prefix)
 
     def start(self):
         print("Starting Montagu...", flush=True)
@@ -147,7 +151,7 @@ class MontaguService:
                       self.use_fake_db_annex, self.prefix)
         print("- Checking Montagu has started successfully")
         sleep(2)
-        if service.status != "running":
-            raise Exception("Failed to start Montagu. Service status is {}".format(service.status))
+        if self.status != "running":
+            raise Exception("Failed to start Montagu. Service status is {}".format(self.status))
 
 __all__ = ["MontaguService"]

--- a/src/service_config/proxy_config.py
+++ b/src/service_config/proxy_config.py
@@ -3,15 +3,14 @@ from os.path import join
 from typing import Dict
 
 from docker_helpers import docker_cp
-from service import service
 
 
-def configure_proxy(cert_paths: Dict[str, str]):
+def configure_proxy(service, cert_paths: Dict[str, str]):
     print("Configuring reverse proxy")
-    add_certificate_to_proxy(cert_paths)
+    add_certificate_to_proxy(service, cert_paths)
 
 
-def add_certificate_to_proxy(cert_paths: Dict[str, str]):
+def add_certificate_to_proxy(service, cert_paths: Dict[str, str]):
     print("- Adding certificate to reverse-proxy container")
     add_certificate(service.proxy, cert_paths, "/etc/montagu/proxy")
 

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -98,6 +98,12 @@ definitions = [
                       "What slack channel should we post in?",
                       "e.g., montagu. Leave as the empty string to not post",
                       default_value=""),
+    BooleanSettingDefinition("clone_reports",
+                             "Should montagu-reports be cloned?",
+                             "If you answer yes, then we need vault access in order to get the ssh keys for vimc-robot "
+                             "If you answer no, then we set up only an empty orderly repository, and you will not be "
+                             "able to clone the reports repository",
+                             default_value=True),
     SettingDefinition("vault_address",
                       "What is the address of the vault?",
                       "If you have a local vault instance for testing, you probably want http://127.0.0.1:8200.\n"
@@ -115,12 +121,6 @@ definitions = [
                       "copies simultaneously.",
                       default_value="montagu"),
 
-    BooleanSettingDefinition("clone_reports",
-                             "Should montagu-reports be cloned?",
-                             "If you answer yes, then we need vault access in order to get the ssh keys for vimc-robot "
-                             "If you answer no, then we set up only an empty orderly repository, and you will not be "
-                             "able to clone the reports repository",
-                             default_value=True),
     BooleanSettingDefinition("require_clean_git",
                              "Should we require a clean git state?",
                              "If you answer yes, then we require that git is 'clean' (no untracked or modified files) "

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -1,10 +1,16 @@
-import backup
+from subprocess import run, DEVNULL
+
 from setting_definitions.boolean import BooleanSettingDefinition
 from setting_definitions.definition import SettingDefinition
 from setting_definitions.enum import EnumSettingDefinition
 
 teamcity_sources = ["test_data", "legacy"]
 
+## NOTE: This duplicates the code in backup.py in order to break a
+## circular dependency.  It would be good to factor that out but I
+## can't see a really obvious decent spot for it.
+def backup_needs_setup():
+    return run("../backup/needs-setup.sh", stdout=DEVNULL, stderr=DEVNULL).returncode == 1
 
 def vault_required(settings):
     data_source = settings["initial_data_source"]
@@ -12,7 +18,7 @@ def vault_required(settings):
     uses_vault_passwords = settings["password_group"] is not None and \
                            settings['password_group'] != "fake"
     return data_source in teamcity_sources \
-           or (uses_duplicati and backup.needs_setup()) \
+           or (uses_duplicati and backup_needs_setup()) \
            or settings["certificate"] == "production" \
            or settings["certificate"] == "support" \
            or uses_vault_passwords \

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -87,6 +87,13 @@ definitions = [
                               ("fake",       "Do not use passwords from the vault")
                           ]
                           ),
+    EnumSettingDefinition("db_annex_type",
+                          "How do we treat the annex database?",
+                          [
+                              ("fake", "Add a totally safe, but empty, version to the constellation"),
+                              ("readonly", "Read-only access to the real annex"),
+                              ("real", "Full access to the real annex: PRODUCTION ONLY")
+                          ]),
     SettingDefinition("vault_address",
                       "What is the address of the vault?",
                       "If you have a local vault instance for testing, you probably want http://127.0.0.1:8200.\n"
@@ -123,12 +130,5 @@ definitions = [
     BooleanSettingDefinition("add_test_user",
                              "Should we add a test user with access to all modelling groups?",
                              "This must set to False on production!",
-                             default_value=False),
-    EnumSettingDefinition("db_annex_type",
-                          "How do we treat the annex database?",
-                          [
-                              ("fake", "Add a totally safe, but empty, version to the constellation"),
-                              ("readonly", "Read-only access to the real annex"),
-                              ("real", "Full access to the real annex: PRODUCTION ONLY")
-                          ])
+                             default_value=False)
 ]

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -100,7 +100,7 @@ definitions = [
     SettingDefinition("port_annex",
                       "What port should the annex listen on?",
                       default_value=15432,
-                      required = lambda x: x["db_annex_type"] == "fake"),
+                      is_required=lambda x: x["db_annex_type"] == "fake"),
     SettingDefinition("notify_channel",
                       "What slack channel should we post in?",
                       "e.g., montagu. Leave as the empty string to not post",

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -65,7 +65,7 @@ definitions = [
                       default_value=443),
     SettingDefinition("port_db",
                       "What port should the database listen on?",
-                      default_value=6543),
+                      default_value=5432),
     SettingDefinition("hostname",
                       "What hostname is Montagu being accessed as?",
                       "This hostname should match the SSL certificate. Likely values:"
@@ -97,6 +97,10 @@ definitions = [
                               ("readonly", "Read-only access to the real annex"),
                               ("real", "Full access to the real annex: PRODUCTION ONLY")
                           ]),
+    SettingDefinition("port_annex",
+                      "What port should the annex listen on?",
+                      default_value=15432,
+                      required = lambda x: x["db_annex_type"] == "fake"),
     SettingDefinition("notify_channel",
                       "What slack channel should we post in?",
                       "e.g., montagu. Leave as the empty string to not post",

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -94,6 +94,10 @@ definitions = [
                               ("readonly", "Read-only access to the real annex"),
                               ("real", "Full access to the real annex: PRODUCTION ONLY")
                           ]),
+    SettingDefinition("notify_channel",
+                      "What slack channel should we post in?",
+                      "e.g., montagu. Leave as the empty string to not post",
+                      default_value=""),
     SettingDefinition("vault_address",
                       "What is the address of the vault?",
                       "If you have a local vault instance for testing, you probably want http://127.0.0.1:8200.\n"
@@ -101,12 +105,8 @@ definitions = [
                       default_value="https://support.montagu.dide.ic.ac.uk:8200",
                       is_required=vault_required),
 
-    SettingDefinition("notify_channel",
-                      "What slack channel should we post in?",
-                      "e.g., montagu. Leave as the empty string to not post",
-                      default_value=""),
     SettingDefinition("instance_name",
-                      "What is the name of this instance to post in a channel?",
+                      "What is the name of this instance?",
                       default_value="(unknown)"),
     SettingDefinition("docker_prefix",
                       "What docker prefix name should we use?  Leave this as "

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -63,6 +63,9 @@ definitions = [
                       "if there is another layer wrapping around Montagu (e.g. if it is being deployed to a VM) the "
                       "real port exposed on the physical machine must agree with the port you choose now.",
                       default_value=443),
+    SettingDefinition("port_db",
+                      "What port should the database listen on?",
+                      default_value=6543),
     SettingDefinition("hostname",
                       "What hostname is Montagu being accessed as?",
                       "This hostname should match the SSL certificate. Likely values:"

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -95,6 +95,12 @@ definitions = [
     SettingDefinition("instance_name",
                       "What is the name of this instance to post in a channel?",
                       default_value="(unknown)"),
+    SettingDefinition("docker_prefix",
+                      "What docker prefix name should we use?  Leave this as "
+                      "'montagu' for the primary deployment on a machine and "
+                      "set to an alternative value if you want to run multiple "
+                      "copies simultaneously",
+                      default_value="montagu"),
 
     BooleanSettingDefinition("clone_reports",
                              "Should montagu-reports be cloned?",

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -63,6 +63,9 @@ definitions = [
                       "if there is another layer wrapping around Montagu (e.g. if it is being deployed to a VM) the "
                       "real port exposed on the physical machine must agree with the port you choose now.",
                       default_value=443),
+    SettingDefinition("port_http",
+                      "What port should Montagu listen for http on?",
+                      default_value=80),
     SettingDefinition("port_db",
                       "What port should the database listen on?",
                       default_value=5432),

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -105,7 +105,7 @@ definitions = [
                       "What docker prefix name should we use?  Leave this as "
                       "'montagu' for the primary deployment on a machine and "
                       "set to an alternative value if you want to run multiple "
-                      "copies simultaneously",
+                      "copies simultaneously.",
                       default_value="montagu"),
 
     BooleanSettingDefinition("clone_reports",

--- a/src/setting_definitions/definition.py
+++ b/src/setting_definitions/definition.py
@@ -14,6 +14,8 @@ class SettingDefinition:
         self.default_value = default_value
         self.first_time_only = first_time_only
         self._is_required = is_required
+        if first_time_only:
+            raise Exception("Don't use first_time_only")
 
     def ask(self):
         print("")

--- a/src/settings.py
+++ b/src/settings.py
@@ -36,11 +36,9 @@ def prepare_for_vault_access(address, quiet=False):
         run(["vault", "auth", "-method=github"], check=True)
 
 
-def get_settings(do_first_time_setup: bool, quiet=False):
+def get_settings(quiet=False):
     settings = load_settings()
     missing = list(d for d in definitions if d.name not in settings)
-    if not do_first_time_setup:
-        missing = list(d for d in missing if not d.first_time_only)
 
     showed_prompt = False
     if any(missing):

--- a/src/stop.py
+++ b/src/stop.py
@@ -6,11 +6,11 @@ from os.path import abspath, dirname
 # will fail for mysterious reasons - it looks like a circular
 # dependency but it seems weird that this would break it.
 import backup
-import service
+from service import MontaguService
 from settings import get_settings
 
 if __name__ == "__main__":
     abspath = abspath(__file__)
     chdir(dirname(abspath))
     settings = get_settings(False)
-    service.service.stop(settings)
+    MontaguService(settings).stop()

--- a/src/stop.py
+++ b/src/stop.py
@@ -12,5 +12,5 @@ from settings import get_settings
 if __name__ == "__main__":
     abspath = abspath(__file__)
     chdir(dirname(abspath))
-    settings = get_settings(False)
+    settings = get_settings()
     MontaguService(settings).stop()

--- a/src/webapp_config.py
+++ b/src/webapp_config.py
@@ -2,10 +2,9 @@ import shutil
 
 from certificates import extract_certificates, cert_dir
 from docker_helpers import docker_cp
-from service import service
 
-
-def configure_webapps(keystore_password):
+## TODO: so far as I can see this is obsolete?
+def configure_webapps(service, keystore_password):
     print("Configuring portals")
     cert_paths = extract_certificates(keystore_password)
     try:

--- a/teamcity-settings.json
+++ b/teamcity-settings.json
@@ -12,5 +12,9 @@
     "add_test_user": false,
     "db_annex_type": "fake",
     "instance_name": "teamcity",
-    "notify_channel": ""
+    "notify_channel": "",
+    "port_http": 80,
+    "port_db": 5432,
+    "port_annex": 15432,
+    "docker_prefix": "montagu"
 }


### PR DESCRIPTION
The title of this PR is a bit of a lie; the vast majority of the PR could be phrased as

> Change `service.service` from being a global variable and initialise it with settings

This is a fairly large set of changes as a result and I can go back and split these two bits out if that seems necessary, though that will take a while of course.

I'm submitting this now before it gets any bigger but there are additional things that *could* be done (here or in a follow up PR/PRs)

* move registry configuration into the service object, either via the settings or a cli argument
* similar work to lift versions into the service object
* webapp_config.py is obsolete and can be removed I believe
* first time setup is obsolete - I'm raising Exception to prove this here, and can purge it too
* configuration file argument so that the second version can be deployed from the same (enormous) montagu checkout and kept in sync with the "main" deployment

One issue with testing this: we don't really have a full set of "deployment types" that is easy to this with.  I have locally tested:

* deploying a fake/minimal/vaultless instance
* the teamcity instance
* an instance much like science/uat (with both fake and readonly annexes)

Note that this introduces a lot of new variables - mostly port numbers.  The defaults will work for every previous instance I believe.