### PR TITLE
Use latest release tag (class refactor)

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -12,7 +12,7 @@ import os
 from subprocess import run
 import sys
 sys.path.append("scripts/release")
-from helpers import get_latest_release_tag, validate_release_tag
+from release_tag import get_latest_release_tag, validate_release_tag
 
 def checkout(version):
     print("checking out version {}".format(version))

--- a/scripts/release/helpers.py
+++ b/scripts/release/helpers.py
@@ -1,4 +1,3 @@
-import re
 import subprocess
 import shlex
 
@@ -8,23 +7,3 @@ def run(cmd, working_dir=None):
     result = subprocess.run(parts, check=True, stdout=subprocess.PIPE,
                             universal_newlines=True, cwd=working_dir)
     return result.stdout.strip()
-
-release_tag_pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:-RC(\d+))?$")
-
-def get_latest_release_tag():
-    tags = run("git tag").split('\n')
-    release_tags = sorted(t for t in tags if release_tag_pattern.match(t))
-    return release_tags[-1]
-
-def validate_release_tag(tag):
-    m = release_tag_pattern.match(tag)
-    if not m:
-        raise Exception("Tag {} does not correspond to pattern".format(tag))
-    return m
-
-def parse_version(tag):
-    v = validate_release_tag(tag).groups()
-    return [int(el) for el in v[:3]] + [float(v[3]) if v[3] else float("inf")]
-
-def version_greater_than(target, than):
-    return parse_version(target) > parse_version(than)

--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -15,7 +15,8 @@ from io import StringIO
 
 from docopt import docopt
 
-from helpers import run, get_latest_release_tag, version_greater_than
+from helpers import run
+from release_tag import get_latest_release_tag, version_greater_than
 from tickets import check_tickets, tag_tickets
 from tickets import NOT_FOUND
 

--- a/scripts/release/release_tag.py
+++ b/scripts/release/release_tag.py
@@ -1,0 +1,62 @@
+import re
+from functools import total_ordering
+from helpers import run
+
+release_tag_pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:-RC(\d+))?$")
+
+
+@total_ordering
+class ReleaseTag:
+    def __init__(self, major, minor, patch, release_candidate):
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.release_candidate = release_candidate
+
+    def __gt__(self, other):
+        return self.as_list() > other.as_list()
+
+    def __eq__(self, other):
+        return self.major == other.major \
+           and self.minor == other.minor \
+           and self.patch == other.patch \
+           and self.release_candidate == other.release_candidate
+
+    def __repr__(self):
+        s = "v{}.{}.{}".format(self.major, self.minor, self.patch)
+        if self.release_candidate:
+            s += "-RC" + self.release_candidate
+        return s
+
+    def as_list(self):
+        return [self.major, self.minor, self.patch, self.release_candidate or float('inf')]
+
+    @classmethod
+    def parse(cls, tag):
+        v = cls.validate(tag).groups()
+        if v[3]:
+            rc = float(v[3])
+        else:
+            rc = None
+        return ReleaseTag(int(v[0]), int(v[1]), int(v[2]), rc)
+
+    @classmethod
+    def validate(cls, tag):
+        m = release_tag_pattern.match(tag)
+        if not m:
+            raise Exception("Tag {} does not correspond to pattern".format(tag))
+        return m
+
+
+def validate_release_tag(tag):
+    return ReleaseTag.validate(tag)
+
+
+def get_latest_release_tag():
+    tags = run("git tag").split('\n')
+    release_tags = sorted(ReleaseTag.parse(t) for t in tags if release_tag_pattern.match(t))
+    return str(release_tags[-1])
+
+
+def version_greater_than(target, than):
+    return ReleaseTag.parse(target) > ReleaseTag.parse(than)

--- a/scripts/release/tag-images.py
+++ b/scripts/release/tag-images.py
@@ -17,7 +17,7 @@ from subprocess import run
 import os
 import re
 import git_helpers
-from helpers import get_latest_release_tag, validate_release_tag
+from release_tag import get_latest_release_tag, validate_release_tag
 
 # This feels like something we should have elsewhere; it's a map of
 # the name of the *repo* (the key here) with the name of the submodule


### PR DESCRIPTION
This is approach no 1 to fix [VIMC-1175](https://vimc.myjetbrains.com/youtrack/issue/VIMC-1175). It is quite a big change, as it moves release tag into a class, but I think the resulting logic is easier to understand and maintain. It gives us nice things, like automatic stringification, and total ordering.

See also #61.