### PR TITLE
Use latest release tag (smaller change)

### DIFF
--- a/scripts/release/helpers.py
+++ b/scripts/release/helpers.py
@@ -13,8 +13,12 @@ release_tag_pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:-RC(\d+))?$")
 
 def get_latest_release_tag():
     tags = run("git tag").split('\n')
-    release_tags = sorted(t for t in tags if release_tag_pattern.match(t))
-    return release_tags[-1]
+    release_tags = sorted(parse_version(t) for t in tags if release_tag_pattern.match(t))
+    latest = release_tags[-1]
+    s = "v{}.{}.{}".format(latest[0], latest[1], latest[2])
+    if latest[3] != float("inf"):
+        s += "-RC" + latest[3]
+    return s
 
 def validate_release_tag(tag):
     m = release_tag_pattern.match(tag)


### PR DESCRIPTION
This is approach no 2 to fix [VIMC-1175](https://vimc.myjetbrains.com/youtrack/issue/VIMC-1175). It is a smaller change, but I think harder to reason about.

See also #60.