### PR TITLE
i1205 - include static website into deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - admin
       - contrib
       - report
+    volumes:
+      - vimc_website_volume:/vimc-website
     command: ${MONTAGU_PORT} ${MONTAGU_HOSTNAME}
   orderly:
     image: ${MONTAGU_REGISTRY}/montagu-orderly:${MONTAGU_ORDERLY_VERSION}
@@ -54,4 +56,5 @@ services:
 volumes:
   db_volume:
   orderly_volume:
+  vimc_website_volume:
   emails:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,8 @@ services:
     image: ${MONTAGU_REGISTRY}/montagu-reverse-proxy:${MONTAGU_PROXY_VERSION}
     ports:
       - "${MONTAGU_PORT}:${MONTAGU_PORT}"
-      - 80:80
+      - "80:80"
+      - "8080:8080"
     depends_on:
       - api
       - reporting_api

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -19,6 +19,7 @@ from service_config.api_config import get_token_keypair, configure_reporting_api
 from settings import get_settings
 from last_deploy import last_deploy_update
 from notify import Notifier
+from vimc_website import build_vimc_website
 
 
 def _deploy():
@@ -103,7 +104,7 @@ def configure_montagu(is_first_time, settings):
     configure_api(passwords['api'], token_keypair_paths, settings["hostname"], send_emails)
     configure_reporting_api(token_keypair_paths)
     configure_proxy(cert_paths)
-
+    build_vimc_website()
 
 def deploy():
     try:

--- a/src/vimc_website.py
+++ b/src/vimc_website.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# For now hardcoding a bunch of stuff into here given that the
+# service restructure is still pending (VIMC-1201)
+import docker
+from docker_helpers import montagu_registry
+
+def build_vimc_website(ref="origin/i1205"):
+    volume_name = "montagu_website_volume"
+    d = docker.client.from_env()
+    img_name = "{}/vimc-website-builder:i1205".format(montagu_registry)
+    img = d.images.pull(img_name)
+    volumes = {
+        volume_name: {"bind": "/srv/jekyll", "mode": "rw"}
+    }
+    try:
+        res = d.containers.run(img, ["build-site.sh", ref],
+                               volumes = volumes, remove = True, tty = True)
+    except docker.errors.ContainerError as e:
+        res = e
+
+if __name__ == "__main__":
+    build_vimc_website()

--- a/src/vimc_website.py
+++ b/src/vimc_website.py
@@ -5,18 +5,29 @@ import docker
 from docker_helpers import montagu_registry
 
 def build_vimc_website(ref="origin/i1205"):
-    volume_name = "montagu_website_volume"
+    volume_name = "montagu_vimc_website_volume"
     d = docker.client.from_env()
     img_name = "{}/vimc-website-builder:i1205".format(montagu_registry)
+    print("Pulling website builder image")
     img = d.images.pull(img_name)
     volumes = {
         volume_name: {"bind": "/srv/jekyll", "mode": "rw"}
     }
-    try:
-        res = d.containers.run(img, ["build-site.sh", ref],
-                               volumes = volumes, remove = True, tty = True)
-    except docker.errors.ContainerError as e:
-        res = e
+    # Note: using create/start/wait rather than run because otherwise
+    # it's really hard to get the logs on failed build (the python
+    # docker package returns only stderr on failure and the error is
+    # in stdout)
+    container = d.containers.create(img, ["build-site.sh", ref],
+                                    volumes = volumes, tty = True)
+    print("Building VIMC website")
+    container.start()
+    if container.wait() != 0:
+        print("...failed")
+        print(container.logs().decode("utf-8"))
+        container.remove()
+        raise Exception("Failed to build website")
+    container.remove()
+    print("...success")
 
 if __name__ == "__main__":
     build_vimc_website()


### PR DESCRIPTION
This builds on the work in https://github.com/vimc/vimc-website/pull/1 and https://github.com/vimc/montagu-proxy/pull/10 - relatively little is needed at the montagu end.  This adds one additional docker volume to the constellation (but no more containers).  There's a small script that will build the site - it can be run without deploying and is run at the end of deploy.  Builds after the first will be much faster, so with persistent volumes this will not slow things down more than about 1s