### PR TITLE
I1434 - copy guidance reports into contrib container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - api
     volumes:
       - template_volume:/usr/share/nginx/html/templates
+      - guidance_volume:/usr/share/nginx/html/guidance
   admin:
     image: ${MONTAGU_REGISTRY}/montagu-admin-portal:${MONTAGU_ADMIN_PORTAL_VERSION}
     depends_on:
@@ -64,5 +65,6 @@ volumes:
   db_volume:
   orderly_volume:
   template_volume:
+  guidance_volume:
   shiny_volume:
   emails:

--- a/src/guidance_report_versions
+++ b/src/guidance_report_versions
@@ -1,1 +1,5 @@
 internal-2017-demography-childmortality/20171114-152328-da1957c2/
+internal-2017-demography-kosovo/20171109-204911-45436ef8/
+internal-2017-demography-tuvalu/20171109-205800-aa3a35c2/
+internal-2017-demography-over80/20171114-094012-ed43d81c/
+internal-2017-demography-marshall/20171109-205347-89919a97/

--- a/src/guidance_report_versions
+++ b/src/guidance_report_versions
@@ -1,0 +1,1 @@
+internal-2017-demography-childmortality/20171114-152328-da1957c2/

--- a/src/service.py
+++ b/src/service.py
@@ -22,7 +22,8 @@ components = {
     "volumes": {
         "db": "db_volume",
         "orderly": "orderly_volume",
-        "templates": "template_volume"
+        "templates": "template_volume",
+        "guidance": "guidance_volume"
     },
     "network": "default"
 }

--- a/src/service_config/contrib_portal_config.py
+++ b/src/service_config/contrib_portal_config.py
@@ -4,11 +4,16 @@ from os.path import join
 
 def configure_contrib_portal(service):
     template_report_paths = get_template_report_versions()
+    guidance_paths = get_guidance_report_versions()
     print("Configuring contrib portal")
     for p in template_report_paths:
         if len(p) > 0:
             path_to_templates = join("archive", p, "*.csv")
             add_templates_to_contrib_portal(service, path_to_templates)
+    for p in guidance_paths:
+        if len(p) > 0:
+            path_to_artefacts = join("archive", p, "*.csv")
+            add_guidance_to_contrib_portal(service, path_to_artefacts)
 
 
 def add_templates_to_contrib_portal(service, path_to_templates):
@@ -16,7 +21,18 @@ def add_templates_to_contrib_portal(service, path_to_templates):
     copy_between_volumes(service.volume_name("orderly"), service.volume_name("templates"), path_to_templates)
 
 
+def add_guidance_to_contrib_portal(service, path_to_templates):
+    print("- Copying burden estimate templates from orderly to contrib portal")
+    copy_between_volumes(service.volume_name("orderly"), service.volume_name("guidance"), path_to_templates)
+
+
 def get_template_report_versions():
     with open("template_report_versions") as f:
+        value = f.read()
+    return [x.strip() for x in value.split("\n") if x]
+
+
+def get_guidance_report_versions():
+    with open("guidance_report_versions") as f:
         value = f.read()
     return [x.strip() for x in value.split("\n") if x]

--- a/src/service_config/contrib_portal_config.py
+++ b/src/service_config/contrib_portal_config.py
@@ -3,36 +3,26 @@ from os.path import join
 
 
 def configure_contrib_portal(service):
-    template_report_paths = get_template_report_versions()
-    guidance_paths = get_guidance_report_versions()
+    template_report_paths = get_report_versions("template_report_versions")
+    guidance_paths = get_report_versions("guidance_report_versions")
     print("Configuring contrib portal")
     for p in template_report_paths:
         if len(p) > 0:
             path_to_templates = join("archive", p, "*.csv")
-            add_templates_to_contrib_portal(service, path_to_templates)
+            add_reports_to_contrib_portal(service, path_to_templates, "templates")
     for p in guidance_paths:
         if len(p) > 0:
             path_to_artefacts = join("archive", p, "*.html")
-            add_guidance_to_contrib_portal(service, path_to_artefacts)
+            add_reports_to_contrib_portal(service, path_to_artefacts, "guidance")
 
 
-def add_templates_to_contrib_portal(service, path_to_templates):
-    print("- Copying burden estimate templates from orderly to contrib portal")
-    copy_between_volumes(service.volume_name("orderly"), service.volume_name("templates"), path_to_templates)
+def add_reports_to_contrib_portal(service, path_to_reports, volume_name):
+    print("- Copying {} reports from orderly to contrib portal".format(volume_name))
+    copy_between_volumes(service.volume_name("orderly"), service.volume_name(volume_name), path_to_reports)
 
 
-def add_guidance_to_contrib_portal(service, path_to_reports):
-    print("- Copying burden estimate templates from orderly to contrib portal")
-    copy_between_volumes(service.volume_name("orderly"), service.volume_name("guidance"), path_to_reports)
-
-
-def get_template_report_versions():
-    with open("template_report_versions") as f:
+def get_report_versions(path):
+    with open(path) as f:
         value = f.read()
     return [x.strip() for x in value.split("\n") if x]
 
-
-def get_guidance_report_versions():
-    with open("guidance_report_versions") as f:
-        value = f.read()
-    return [x.strip() for x in value.split("\n") if x]

--- a/src/service_config/contrib_portal_config.py
+++ b/src/service_config/contrib_portal_config.py
@@ -21,9 +21,9 @@ def add_templates_to_contrib_portal(service, path_to_templates):
     copy_between_volumes(service.volume_name("orderly"), service.volume_name("templates"), path_to_templates)
 
 
-def add_guidance_to_contrib_portal(service, path_to_templates):
+def add_guidance_to_contrib_portal(service, path_to_reports):
     print("- Copying burden estimate templates from orderly to contrib portal")
-    copy_between_volumes(service.volume_name("orderly"), service.volume_name("guidance"), path_to_templates)
+    copy_between_volumes(service.volume_name("orderly"), service.volume_name("guidance"), path_to_reports)
 
 
 def get_template_report_versions():

--- a/src/service_config/contrib_portal_config.py
+++ b/src/service_config/contrib_portal_config.py
@@ -12,7 +12,7 @@ def configure_contrib_portal(service):
             add_templates_to_contrib_portal(service, path_to_templates)
     for p in guidance_paths:
         if len(p) > 0:
-            path_to_artefacts = join("archive", p, "*.csv")
+            path_to_artefacts = join("archive", p, "*.html")
             add_guidance_to_contrib_portal(service, path_to_artefacts)
 
 


### PR DESCRIPTION
Have confirmed this works locally, i.e. the report paths are valid and result in exposing:

`../contribution/guidance/child-mortality.html`
`../contribution/guidance/over80.html`
`../contribution/guidance/kosovo_demography.html`
`../contribution/guidance/marshall_demography.html`
`../contribution/guidance/tuvalu_demography.html`

One question I have here is whether the info in these reports is at all sensitive?
With the templates we don't worry about them being publicly viewable because they contain no data; I don't know if that is true here or whether we'd want to lock them down to logged in users (I guess we'd have to use Caddy if so!!)
@weshinsley do you know the answer?