### PR TITLE
i1466: logging via systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Montagu
 ## Prerequisites
 * [Docker Community Edition](https://docs.docker.com/engine/installation/) 
-* [Docker Compose](https://docs.docker.com/compose/install/)
+* [Docker Compose](https://docs.docker.com/compose/install/) - at least version 0.17.0
 * Python 3 and pip (Python 3 is included with Ubunti. For pip, use `apt install python3-pip`)
 * [Vault](https://www.vaultproject.io/downloads.html) available on the command line as `vault`, with the address set via `export VAULT_ADDR=https://support.montagu.dide.ic.ac.uk:8200`
 * Your machine needs to trust our Docker Registry. See 
@@ -145,3 +145,12 @@ which generates a new set of passwords for the same users as the group specified
 ## Development
 To update `src/versions.py` to the latest master of each sub repo, use 
 `src/update_versions_to_latest_master.py`.
+
+## Logging
+
+We log to systemd.  All logs will have the tag `DOCKER_TAG=montagu` which allows for filtering with
+
+```
+journalctl --since=today CONTAINER_TAG=montagu
+journalctl --since=today CONTAINER_NAME=montagu_db_1
+```

--- a/docker-compose-annex.yml
+++ b/docker-compose-annex.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   db_annex:
     image: ${MONTAGU_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,3 +76,6 @@ volumes:
   template_volume:
   shiny_volume:
   emails:
+
+logging:
+  driver: journald

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-version: '2'
+version: '2.1'
+
 services:
   api:
     image: ${MONTAGU_REGISTRY}/montagu-api:${MONTAGU_API_VERSION}
     restart: always
+    logging: *log-journald
     depends_on:
       - db
     volumes:
@@ -12,6 +14,7 @@ services:
   reporting_api:
     image: ${MONTAGU_REGISTRY}/montagu-reporting-api:${MONTAGU_REPORTING_API_VERSION}
     restart: always
+    logging: *log-journald
     volumes:
       - orderly_volume:/orderly
     depends_on:
@@ -19,6 +22,7 @@ services:
   db:
     image: ${MONTAGU_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}
     restart: always
+    logging: *log-journald
     ports:
       - "5432:5432"
     volumes:
@@ -26,6 +30,7 @@ services:
   contrib:
     image: ${MONTAGU_REGISTRY}/montagu-contrib-portal:${MONTAGU_CONTRIB_PORTAL_VERSION}
     restart: always
+    logging: *log-journald
     depends_on:
       - api
     volumes:
@@ -33,17 +38,20 @@ services:
   admin:
     image: ${MONTAGU_REGISTRY}/montagu-admin-portal:${MONTAGU_ADMIN_PORTAL_VERSION}
     restart: always
+    logging: *log-journald
     depends_on:
       - api
   report:
     image: ${MONTAGU_REGISTRY}/montagu-report-portal:${MONTAGU_REPORT_PORTAL_VERSION}
     restart: always
+    logging: *log-journald
     depends_on:
       - api
       - reporting_api
   proxy:
     image: ${MONTAGU_REGISTRY}/montagu-reverse-proxy:${MONTAGU_PROXY_VERSION}
     restart: always
+    logging: *log-journald
     ports:
       - "${MONTAGU_PORT}:${MONTAGU_PORT}"
       - 80:80
@@ -57,6 +65,7 @@ services:
   orderly:
     image: ${MONTAGU_REGISTRY}/montagu-orderly:${MONTAGU_ORDERLY_VERSION}
     restart: always
+    logging: *log-journald
     volumes:
       - orderly_volume:/orderly
       - shiny_volume:/shiny
@@ -64,11 +73,13 @@ services:
   shiny:
     image: ${MONTAGU_REGISTRY}/montagu-shiny:${MONTAGU_SHINY_VERSION}
     restart: always
+    logging: *log-journald
     volumes:
       - shiny_volume:/srv/shiny-server/apps
   shiny_proxy:
     image: ${MONTAGU_REGISTRY}/montagu-shiny-proxy:${MONTAGU_SHINY_VERSION}
     restart: always
+    logging: *log-journald
 
 volumes:
   db_volume:
@@ -77,5 +88,17 @@ volumes:
   shiny_volume:
   emails:
 
-logging:
+# This is the recommended way of injecting common blocks into a docker
+# compose file, see:
+#
+# https://docs.docker.com/compose/compose-file/#extension-fields
+# https://github.com/docker/compose/issues/3231
+#
+# &log-journald defines a yaml anchor and *log-journald elsewhere
+# references it.  The leading 'x-' in the definition is important to
+# mark this field as an extensionm field.
+x-logging:
+  &log-journald
   driver: journald
+  options:
+    tag: montagu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,20 @@
 version: '2.1'
 
+# This is the recommended way of injecting common blocks into a docker
+# compose file, see:
+#
+# https://docs.docker.com/compose/compose-file/#extension-fields
+# https://github.com/docker/compose/issues/3231
+#
+# &log-journald defines a yaml anchor and *log-journald elsewhere
+# references it - it must come early in the file.  The leading 'x-' in
+# the definition is important to mark this field as an extension
+# field.
+x-logging: &log-journald
+  driver: journald
+  options:
+    tag: montagu
+
 services:
   api:
     image: ${MONTAGU_REGISTRY}/montagu-api:${MONTAGU_API_VERSION}
@@ -87,18 +102,3 @@ volumes:
   template_volume:
   shiny_volume:
   emails:
-
-# This is the recommended way of injecting common blocks into a docker
-# compose file, see:
-#
-# https://docs.docker.com/compose/compose-file/#extension-fields
-# https://github.com/docker/compose/issues/3231
-#
-# &log-journald defines a yaml anchor and *log-journald elsewhere
-# references it.  The leading 'x-' in the definition is important to
-# mark this field as an extensionm field.
-x-logging:
-  &log-journald
-  driver: journald
-  options:
-    tag: montagu


### PR DESCRIPTION
Please note - this requires docker-compose 1.17.0 or greater.  If you do not have that version you will get an error like:

```
The Compose file './../docker-compose.yml' is invalid because:
Additional properties are not allowed ('x-logging' was unexpected)

You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version ("2.0", "2.1", "3.0", "3.1", "3.2") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```

I have not added logging to the (fake) annex because we don't use that in production.  I can add it if needed but it will require duplicating the contents of the `x-logging` section into the annex configuration.