### PR TITLE
i1430 - Release script doesn't always tag in YouTrack

### DIFF
--- a/scripts/release/tickets.py
+++ b/scripts/release/tickets.py
@@ -138,7 +138,7 @@ def tag_tickets(tickets, tag):
 
     for ticket in tickets:
         if ticket == NOT_FOUND:
-            break
+            continue
         success, response = yt.modify_ticket(ticket.id, "Fixed in build " + tag)
         if not success:
             template = "Failed to tag {id}. {status}: {text}"


### PR DESCRIPTION
If one branch doesn't have a ticket, should `continue` rather than `break` the loop.