### PR TITLE
i1675: Increase size of ram and disks

### DIFF
--- a/staging/Vagrantfile
+++ b/staging/Vagrantfile
@@ -4,8 +4,8 @@ Vagrant.require_version ">= 1.8.2"
 
 domain = 'localdomain'
 box = "bento/ubuntu-16.04"
-ram_size_mb = '3072'
-data_disk_size_gb = 200
+ram_size_mb = '16384'
+data_disk_size_gb = 900
 
 permanent = [
   { 


### PR DESCRIPTION
- RAM increased to avoid an OOM error on a science import 3 * 16 GB = 48 of the 125 on the machine, leaving 77 for the on-metal docker (vault, registry) and for the four CI machines
- Disk increased to 900GB, reflecting the size of production's disk