### PR TITLE
i1682: Install and schedule bb8 during deploy 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "submodules/shiny"]
 	path = submodules/shiny
 	url = https://github.com/vimc/montagu-shiny
+[submodule "montagu-bb8"]
+	path = montagu-bb8
+	url = https://github.com/vimc/montagu-bb8

--- a/src/backup.py
+++ b/src/backup.py
@@ -29,7 +29,7 @@ def needs_setup():
 
 def setup(service):
     if needs_setup():
-        print("- Configuring and installing backup service")
+        print("- Configuring and installing Duplicati backup service")
         configure(service)
         run("../backup/setup.sh", check=True)
 
@@ -38,19 +38,19 @@ def backup(service):
     # Note, it is safe to run the backup on a running system, as pg_dump uses TRANSACTION ISOLATION LEVEL SERIALIZABLE
     # i.e. The backup will only see transactions that were committed before the isolation level was set.
     # So we will get a consistent backup, even if changes are being made.
-    print("Performing backup")
+    print("Performing Duplicati backup")
     setup(service)
     run("../backup/backup.py", check=True)
 
 
 def schedule(service):
-    print("Scheduling backup")
+    print("Scheduling Duplicati backup")
     setup(service)
     run(["../backup/schedule.py", "--no-immediate-backup"], check=True)
 
 
 def restore(service):
-    print("Restoring from remote backup")
+    print("Restoring from remote Duplicati backup")
     setup(service)
     ## Because of the annex work we need to ensure that users *exist*
     ## here at this point and do that just before restoring the

--- a/src/bb8_backup.py
+++ b/src/bb8_backup.py
@@ -32,7 +32,7 @@ def backup():
 @requires_bb8_setup
 def schedule():
     print("Scheduling bb8 backup")
-    run("./schedule.sh", cwd=bb8_dir, check=True)
+    run("./schedule", cwd=bb8_dir, check=True)
 
 
 @requires_bb8_setup

--- a/src/bb8_backup.py
+++ b/src/bb8_backup.py
@@ -11,13 +11,15 @@ def requires_bb8_setup(func):
         if not finished_setup:
             setup()
         return func(*args, **kwargs)
+
     return decorated
 
 
 def setup():
     global finished_setup
-    print("- Configuring and installing bb8 backup service with these "
-          f"targets: {targets}")
+    template = "- Configuring and installing bb8 backup service with these " \
+               "targets: {}"
+    print(template.format(targets))
     args = ["./setup.sh", "../config.json"] + targets
     run(args, cwd=bb8_dir, check=True)
     finished_setup = True

--- a/src/bb8_backup.py
+++ b/src/bb8_backup.py
@@ -1,0 +1,41 @@
+from subprocess import run
+
+targets = ["orderly"]
+finished_setup = False
+bb8_dir = "../montagu-bb8/bb8"
+
+
+def requires_bb8_setup(func):
+    def decorated(*args, **kwargs):
+        global finished_setup
+        if not finished_setup:
+            setup()
+        return func(*args, **kwargs)
+    return decorated
+
+
+def setup():
+    global finished_setup
+    print("- Configuring and installing bb8 backup service with these "
+          f"targets: {targets}")
+    args = ["./setup.sh", "../config.json"] + targets
+    run(args, cwd=bb8_dir, check=True)
+    finished_setup = True
+
+
+@requires_bb8_setup
+def backup():
+    print("Performing bb8 backup")
+    run(["bb8", "backup"], check=True)
+
+
+@requires_bb8_setup
+def schedule():
+    print("Scheduling bb8 backup")
+    run("./schedule.sh", cwd=bb8_dir, check=True)
+
+
+@requires_bb8_setup
+def restore():
+    print("Restoring from remote bb8 backup")
+    run(["bb8", "restore"], check=True)

--- a/src/bb8_backup.py
+++ b/src/bb8_backup.py
@@ -1,3 +1,4 @@
+from os.path import abspath
 from subprocess import run
 
 targets = ["orderly"]
@@ -20,7 +21,8 @@ def setup():
     template = "- Configuring and installing bb8 backup service with these " \
                "targets: {}"
     print(template.format(targets))
-    args = ["./setup.sh", "../config.json"] + targets
+    config_path = abspath("../montagu-bb8/config.json")
+    args = ["./setup.sh", config_path] + targets
     run(args, cwd=bb8_dir, check=True)
     finished_setup = True
 

--- a/src/bb8_backup.py
+++ b/src/bb8_backup.py
@@ -22,7 +22,7 @@ def setup():
                "targets: {}"
     print(template.format(targets))
     config_path = abspath("../montagu-bb8/config.json")
-    args = ["./setup.sh", config_path] + targets
+    args = ["./setup", config_path] + targets
     run(args, cwd=bb8_dir, check=True)
     finished_setup = True
 

--- a/src/data_import.py
+++ b/src/data_import.py
@@ -20,6 +20,7 @@ def do(service):
         import_dump(service.db, local_path)
     elif source == "restore":
         backup.restore(service)
+    elif source == "bb8_restore":
         bb8_backup.restore()
     else:
         raise Exception("Unknown mode '{}'".format(source))

--- a/src/data_import.py
+++ b/src/data_import.py
@@ -1,6 +1,7 @@
 from subprocess import check_output
 
 import backup
+import bb8_backup
 import versions
 from docker_helpers import docker_cp
 from teamcity import save_artifact
@@ -19,6 +20,7 @@ def do(service):
         import_dump(service.db, local_path)
     elif source == "restore":
         backup.restore(service)
+        bb8_backup.restore()
     else:
         raise Exception("Unknown mode '{}'".format(source))
 

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -5,6 +5,7 @@ from os.path import abspath, dirname
 from time import sleep
 
 import backup
+import bb8_backup
 import data_import
 import database
 import orderly
@@ -55,6 +56,7 @@ def _deploy():
     # If Montagu is running, back it up before tampering with it
     if (status == "running") and settings["backup"]:
         backup.backup(service)
+        bb8_backup.backup()
 
     # Stop Montagu if it is running
     # (and delete data volume if persist_data is False)
@@ -66,6 +68,7 @@ def _deploy():
     # Schedule backups
     if settings["backup"]:
         backup.schedule(service)
+        bb8_backup.schedule()
 
     # Start Montagu again
     service.start()

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -54,9 +54,11 @@ def _deploy():
     service.pull()
 
     # If Montagu is running, back it up before tampering with it
-    if (status == "running") and settings["backup"]:
-        backup.backup(service)
-        bb8_backup.backup()
+    if status == "running":
+        if settings["backup"]:
+            backup.backup(service)
+        if settings["bb8_backup"]:
+            bb8_backup.backup()
 
     # Stop Montagu if it is running
     # (and delete data volume if persist_data is False)
@@ -68,6 +70,7 @@ def _deploy():
     # Schedule backups
     if settings["backup"]:
         backup.schedule(service)
+    if settings["bb8_backup"]:
         bb8_backup.schedule()
 
     # Start Montagu again

--- a/src/orderly.py
+++ b/src/orderly.py
@@ -16,7 +16,7 @@ def configure_orderly(service, initialise_volume):
     configure_orderly_ssh(service)
     # Then this requires an empty directory:
     source_setting = service.settings["initial_data_source"]
-    if initialise_volume and source_setting != "restore":
+    if initialise_volume and source_setting not in ["restore", "bb8_restore"]:
         print("Setting up orderly store")
         initialise_orderly_store(service)
     # Then set up some passwords

--- a/src/restore_db.py
+++ b/src/restore_db.py
@@ -9,6 +9,7 @@ from os.path import abspath, dirname
 from os import chdir
 from cli import add_test_user
 
+
 def restore_db():
     settings = get_settings()
     service = MontaguService(settings)
@@ -30,6 +31,7 @@ def restore_db():
                           settings['instance_name'])
         except:
             raise
+
 
 if __name__ == "__main__":
     abspath = abspath(__file__)

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -17,10 +17,12 @@ def backup_needs_setup():
 def vault_required(settings):
     data_source = settings["initial_data_source"]
     uses_duplicati = settings["backup"] is True or data_source == "restore"
+    uses_bb8 = settings["bb8_backup"] is True or data_source == "bb8_restore"
     uses_vault_passwords = settings["password_group"] is not None and \
                            settings['password_group'] != "fake"
     return data_source in teamcity_sources \
            or (uses_duplicati and backup_needs_setup()) \
+           or uses_bb8 \
            or settings["certificate"] == "production" \
            or settings["certificate"] == "support" \
            or uses_vault_passwords \
@@ -36,17 +38,25 @@ definitions = [
                              " should be persisted for live systems, and not persisted for testing systems.",
                              default_value=True),
     BooleanSettingDefinition("backup",
-                             "Should data be backed up remotely?",
+                             "Should data be backed up remotely using "
+                             "Duplicati?",
                              "This should be enabled for the production environment.",
+                             default_value=True),
+    BooleanSettingDefinition("bb8_backup",
+                             "Should data be backed up remotely using BB8?",
+                             "This should be enabled for the production "
+                             "environment.",
                              default_value=True),
     EnumSettingDefinition("initial_data_source",
                           "What data should be imported initially?",
                           [
-                              ("minimal", "Minimum required for Montagu to work (this includes enum tables and "
+                              ("minimal", "Minimum required for Montagu to "
+                                          "work (this includes enum tables and "
                                           "permissions)"),
                               ("test_data", "Fake data, useful for testing"),
                               ("legacy", "Imported data from SDF versions 6, 7, 8 and 12"),
-                              ("restore", "Restore from backup")
+                              ("restore", "Restore from Duplicati backup"),
+                              ("bb8_restore", "Restore from BB8 backup")
                           ],
                           default_value="restore"),
     SettingDefinition("backup_bucket",

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -142,7 +142,8 @@ definitions = [
                              "This must set to False on production!",
                              default_value=False),
     BooleanSettingDefinition("include_template_reports",
-                             "Should we copy burden estimate templates from orderly into the contrib portal container?",
-                             "",
+                             "Should we copy burden estimate templates from "
+                             "orderly into the contrib portal container?",
+                             "This can only be true if data source is restore",
                              default_value=False)
 ]

--- a/teamcity-settings.json
+++ b/teamcity-settings.json
@@ -6,6 +6,7 @@
     "hostname": "localhost",
     "certificate": "self_signed",
     "backup": false,
+    "bb8_backup": false,
     "password_group": "fake",
     "clone_reports": false,
     "require_clean_git": false,


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1682

This also adds the ability to restore from bb8 as the initial data source. But I've only got bb8 working for the orderly volume, which is the easy bit. There are other tickets for database backup via barman, and database restore from bb8.

First merge https://github.com/vimc/montagu/pull/92 and https://github.com/vimc/bb8/pull/20, and update the montagu-bb8 submodule.