### PR TITLE
i1724: Set root password unconditionally

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -277,9 +277,9 @@ def setup(service, annex_settings):
     print("- Scrambling root password")
     if password_group is not None:
         root_password = GeneratePassword().get()
-        set_root_password(service, root_password)
     else:
         root_password = 'changeme'
+    set_root_password(service, root_password)
 
     print("- Getting user configurations")
     users = user_configs(password_group)


### PR DESCRIPTION
As used on uat

We should eventually move to using real passwords (can be done outside of PR with a configuration change) and then eventually to refusing to restore with fake passwords