### PR TITLE
Try to avoid rebuilding when not necessary

### DIFF
--- a/scripts/auto-update-and-commit.sh
+++ b/scripts/auto-update-and-commit.sh
@@ -2,15 +2,21 @@
 set -ex
 message=$(./src/update_versions_to_latest_master.py)
 # https://stackoverflow.com/a/3879077/777939
-git diff-index --quiet HEAD -- && echo "No changes detected" && exit 0;
-echo "Changes detected"
+git diff-index --quiet HEAD -- && echo "No changes detected" && exit 0
+echo "Changes detected relative to origin/master"
+
+# For some reason, the submodules must be added for "git diff --quiet"
+# to behave as expected. But we were going to do that before commit anyway.
+git add submodules
+git diff --quiet origin/latest -- submodules && \
+    echo "origin/latest contains submodule updates already" && exit 0
+echo "Changes detected relative to origin/latest"
+git reset
 
 git remote set-url origin git@github.com:vimc/montagu
 git push --delete origin latest || true
 git branch -D latest || true
 git checkout -b latest
-
-git add submodules
 git commit -m "Auto: Update versions to latest
 
 $message"

--- a/scripts/auto-update-and-commit.sh
+++ b/scripts/auto-update-and-commit.sh
@@ -11,7 +11,6 @@ git add submodules
 git diff --quiet origin/latest -- submodules && \
     echo "origin/latest contains submodule updates already" && exit 0
 echo "Changes detected relative to origin/latest"
-git reset
 
 git remote set-url origin git@github.com:vimc/montagu
 git push --delete origin latest || true


### PR DESCRIPTION
With apologies for the git mess that I created here :cry: 

This prevents a string of builds like one can see in the automated feed channels last night.  It checks not only that the submodules have changed but that they are different to the last copy of `latest`.  So far so good!

This does about half of what is needed! The missing bit is I think we get a false negative at the moment if `master` has commits that `latest` doesn't have to the deploy code.