### PR TITLE
i2219: Enable production db config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     image: ${MONTAGU_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}
     restart: always
     logging: *log-journald
-    command: ${MONTAGU_DB_CONF:-/etc/montagu/postgresql.conf}
+    command: ${MONTAGU_DB_CONF}
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     image: ${MONTAGU_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}
     restart: always
     logging: *log-journald
+    command: ${MONTAGU_DB_CONF:-/etc/montagu/postgresql.conf}
     ports:
       - "5432:5432"
     volumes:

--- a/src/compose.py
+++ b/src/compose.py
@@ -35,7 +35,7 @@ def run(args, settings):
 def get_env(settings):
     port = settings["port"]
     hostname = settings["hostname"]
-    return {
+    env = {
         'MONTAGU_REGISTRY': montagu_registry,
 
         'MONTAGU_PORT': str(port),
@@ -54,3 +54,6 @@ def get_env(settings):
         'MONTAGU_ORDERLY_VERSION': versions.orderly,
         'MONTAGU_SHINY_VERSION': versions.shiny
     }
+    if settings["use_production_db_config"]:
+        env["MONTAGU_DB_CONF"] = "/etc/montagu/postgresql.production.conf"
+    return env

--- a/src/compose.py
+++ b/src/compose.py
@@ -35,7 +35,12 @@ def run(args, settings):
 def get_env(settings):
     port = settings["port"]
     hostname = settings["hostname"]
-    env = {
+    if settings["use_production_db_config"]:
+        db_config_file = "postgresql.production.conf"
+    else:
+        db_config_file = "postgresql.conf"
+
+    return {
         'MONTAGU_REGISTRY': montagu_registry,
 
         'MONTAGU_PORT': str(port),
@@ -43,7 +48,9 @@ def get_env(settings):
 
         'MONTAGU_API_VERSION': versions.api,
         'MONTAGU_REPORTING_API_VERSION': versions.reporting_api,
+
         'MONTAGU_DB_VERSION': versions.db,
+        'MONTAGU_DB_CONF': "/etc/montagu/" + db_config_file,
 
         'MONTAGU_CONTRIB_PORTAL_VERSION': versions.contrib_portal,
         'MONTAGU_ADMIN_PORTAL_VERSION': versions.admin_portal,
@@ -54,6 +61,3 @@ def get_env(settings):
         'MONTAGU_ORDERLY_VERSION': versions.orderly,
         'MONTAGU_SHINY_VERSION': versions.shiny
     }
-    if settings["use_production_db_config"]:
-        env["MONTAGU_DB_CONF"] = "/etc/montagu/postgresql.production.conf"
-    return env

--- a/src/setting_definitions/__init__.py
+++ b/src/setting_definitions/__init__.py
@@ -52,7 +52,7 @@ definitions = [
     BooleanSettingDefinition("open_browser",
                              "Open the browser after deployment?",
                              "If you answer yes, Montagu will be opened after deployment",
-                             default_value=True),
+                             default_value=False),
     SettingDefinition("port",
                       "What port should Montagu listen on?",
                       "Note that this port must be the one that users browsers will be connecting to. In other words, "
@@ -64,8 +64,8 @@ definitions = [
                       "This hostname should match the SSL certificate. Likely values:"
                       "\n- localhost (for local dev)"
                       "\n- support.montagu.dide.ic.ac.uk (for stage)"
-                      "\n- montagu.vaccineimpact.org (for production)"
-                      ),
+                      "\n- montagu.vaccineimpact.org (for production)",
+                      default_value="localhost"),
     EnumSettingDefinition("certificate",
                           "What SSL certificate should Montagu use?",
                           [
@@ -73,23 +73,24 @@ definitions = [
                               ("self_signed_fresh", "Generate a new, non-secure self-signed certificate every deploy"),
                               ("production", "Certificate for montagu.vaccineimpact.org"),
                               ("support", "Certificate for support.montagu.dide.ic.ac.uk")
-                          ]
-                          ),
+                          ],
+                          default_value="self_signed"),
     EnumSettingDefinition("password_group",
                           "Which password group should montagu use to retrieve database passwords from the vault?",
                           [
                               ("production", "Passwords for production"),
                               ("science", "Passwords for science"),
                               ("fake", "Do not use passwords from the vault")
-                          ]
-                          ),
+                          ],
+                          default_value="fake"),
     EnumSettingDefinition("db_annex_type",
                           "How do we treat the annex database?",
                           [
                               ("fake", "Add a totally safe, but empty, version to the constellation"),
                               ("readonly", "Read-only access to the real annex"),
                               ("real", "Full access to the real annex: PRODUCTION ONLY")
-                          ]),
+                          ],
+                          default_value="fake"),
     SettingDefinition("notify_channel",
                       "What slack channel should we post in?",
                       "e.g., montagu. Leave as the empty string to not post",
@@ -129,5 +130,10 @@ definitions = [
                              "Should we copy burden estimate templates from "
                              "orderly into the contrib portal container?",
                              "This can only be true if data source is restore",
+                             default_value=False),
+    BooleanSettingDefinition("use_production_db_config",
+                             "Should we use the high-performance database "
+                             "config?",
+                             "This uses more memory",
                              default_value=False)
 ]

--- a/src/settings.py
+++ b/src/settings.py
@@ -76,7 +76,7 @@ def get_settings(quiet=False):
 
 def save_settings(settings):
     with open(path, 'w') as f:
-        json.dump(settings, f, indent=4)
+        json.dump(settings, f, indent="  ", sort_keys=True)
 
 
 def get_secret(secret_path, field="value"):

--- a/src/settings.py
+++ b/src/settings.py
@@ -24,8 +24,7 @@ def load_settings():
             settings[key] = data[key]
 
     # now re-write file to make sure only the settings used are persisted
-    with open(path, 'w') as f:
-        json.dump(settings, f)
+    save_settings(settings)
     return settings
 
 

--- a/teamcity-settings.json
+++ b/teamcity-settings.json
@@ -16,5 +16,6 @@
     "notify_channel": "",
     "enable_db_replication": false,
     "update_on_deploy": false,
-    "include_template_reports":false
+    "include_template_reports": false,
+    "use_production_db_config": false
 }


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-2219

I also:

* Made `montagu-deploy.json` more readable, by sorting indenting and sorting the keys
* Added defaults to a bunch of the settings, to make it easier to quickly set up a local test instance from scratch (which is when I am most often repeatedly answering these questions)