### PR TITLE
i2486: validate settings

### DIFF
--- a/scripts/check-settings
+++ b/scripts/check-settings
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# This feels like a real fight, unfortunately: we need to import some
+# code from a module in 'src' that is not really set up for relative
+# imports.  Eventually this should be packaged up nicely but I think
+# that should wait until we do a big refactor on the deploy code.  For
+# now there's an awkward boostrap phase here.
+from pathlib import Path
+import os
+import sys
+montagu_root = os.path.abspath(str(Path(__file__).parent.parent))
+sys.path.insert(1, "{}/src".format(montagu_root))
+import settings
+
+
+if __name__ == "__main__":
+    settings.validate_settings_directory(montagu_root)

--- a/settings/production.json
+++ b/settings/production.json
@@ -16,5 +16,6 @@
   "add_test_user": false,
   "hostname": "montagu.vaccineimpact.org",
   "open_browser": false,
+  "use_production_db_config": true,
   "enable_db_replication": true
 }

--- a/settings/restore-test.json
+++ b/settings/restore-test.json
@@ -16,5 +16,6 @@
   "initial_data_source": "bb8_restore",
   "notify_channel": "montagu-deploy",
   "update_on_deploy": true,
+  "use_production_db_config": true,
   "persist_data": true
 }

--- a/settings/science.json
+++ b/settings/science.json
@@ -16,5 +16,6 @@
   "initial_data_source": "bb8_restore",
   "notify_channel": "montagu-deploy",
   "update_on_deploy": true,
+  "use_production_db_config": true,
   "persist_data": true
 }

--- a/src/settings.py
+++ b/src/settings.py
@@ -6,10 +6,10 @@ from subprocess import check_output, run
 
 from setting_definitions import definitions, vault_required
 
-path = 'montagu-deploy.json'
+default_path = 'montagu-deploy.json'
 
 
-def load_settings():
+def load_settings(path=default_path):
     settings = {}
 
     try:
@@ -39,8 +39,8 @@ def prepare_for_vault_access(address, quiet=False):
         run(["vault", "login", "-method=github"], check=True)
 
 
-def get_settings(quiet=False):
-    settings = load_settings()
+def get_settings(quiet=False, path=default_path):
+    settings = load_settings(path)
     missing = list(d for d in definitions if d.name not in settings)
 
     showed_prompt = False
@@ -73,7 +73,7 @@ def get_settings(quiet=False):
     return settings
 
 
-def save_settings(settings):
+def save_settings(settings, path=default_path):
     with open(path, 'w') as f:
         json.dump(settings, f, indent="  ", sort_keys=True)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -39,6 +39,30 @@ def prepare_for_vault_access(address, quiet=False):
         run(["vault", "login", "-method=github"], check=True)
 
 
+def validate_settings(path=default_path):
+    settings = load_settings(path)
+    missing = list(d for d in definitions if d.name not in settings)
+    ret = []
+    for d in missing:
+        if d.is_required(settings):
+            ret.append(d.name)
+    return ret
+
+
+def validate_settings_directory(montagu_root):
+    files = os.listdir("{}/settings".format(montagu_root))
+    files.sort()
+
+    errs = []
+    for f in files:
+        p = "{}/settings/{}".format(montagu_root, f)
+        errs += ["  - settings/{}: {}".format(f, x)
+                 for x in validate_settings(p)]
+    if errs:
+        msg = "Missing configuration entries:\n" + "\n".join(errs)
+        raise Exception(msg)
+
+
 def get_settings(quiet=False, path=default_path):
     settings = load_settings(path)
     missing = list(d for d in definitions if d.name not in settings)


### PR DESCRIPTION
This needs enabling on TC after merge.  Main script is

`./scripts/check-settings`

To test, try working on 5fcfc8e where the script errors on 3 settings files; e12cb9b fixes this