### PR TITLE
i1747: Remove need for sudo from deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 * Upgrading and rebooting servers, disaster recovery: [docs](https://github.com/vimc/montagu-machine/tree/master/docs/)
 
 ## Deploy
-As root:
 
-1. `(cd src && pip3 install --user -r requirements.txt)`
-2. `./src/deploy.py`
+1. Install python packages with `pip3 install --user -r src/requirements.txt`
+2. If restoring from backup (or making backups) prepare bb8 with `sudo montagu-bb8/bb8/bb8_link_write`
+3. `./src/deploy.py`
 
 ### Deploy a specific version
 
@@ -52,41 +52,11 @@ When deploying to a testing environment using real data restored from live,
 setting the `add_test_user` option to true adds the above user with permissions 
 to all modelling groups and reports.
 
-### Root privileges
-When deploying to the live server, make sure to first become the root user by 
-running `sudo su`. This is neccessary to have the correct environment variables 
-for the backup to run.
+### The montagu user
 
-### Backup
-If you set the initial data source to "restore", or you enable backups, the 
-deploy tool will automatically configure our 
-[backup tool](https://github.com/vimc/montagu-backup). To do so, it needs to
-obtain an encryption key from the Vault. Once this has run once, the encryption
-key and backup settings are saved to `/etc/montagu/backup`. Upon future runs of
-the deploy tool, backup configuration will be skipped (using 
-`backup/needs-setup.sh` as the test). If you know something has changed and you
-want to force a rerun, delete the existing configuration 
-(`sudo rm -r /etc/montagu/backup`).
-
-### Database restore
-
-The database can be restored without redeploying all of montagu.
-
-```
-sudo -E ./src/restore_db.py
-```
-
-(The `sudo` is required because the backup scripts require it, and the `-E` allows the `sudo` shell to read your vault credentials.)
-
-This can be setup as a cron job to run every night (as is on `science`) by adding a file containing
-
-```
-0 6 * * * root /home/vagrant/montagu/restore_db.py
-```
-
-as `/etc/cron.d/montagu-restore-db`.
-
-However, care should be taken here because if the schema has been migrated in the production database the montagu api may not be able to talk to the database.  In practice this is probably not that much of a problem as we can just redeploy (and often will have deployed on science before deploying on production).
+When deploying to the production server, make sure to first become the
+`montagu` user by connecting to production as
+`montagu@production.montagu.dide.ic.ac.uk`
 
 ## Passwords
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Deploy
 
 1. Install python packages with `pip3 install --user -r src/requirements.txt`
-2. If restoring from backup (or making backups) prepare bb8 with `sudo montagu-bb8/bb8/bb8_link_write`
+2. If restoring from backup (or making backups) prepare bb8 with `sudo ./montagu-bb8/bb8/bb8_link_write`
 3. `./src/deploy.py`
 
 ### Deploy a specific version

--- a/ReleaseProcess.md
+++ b/ReleaseProcess.md
@@ -13,9 +13,8 @@
 5. You may go through multiple rounds of steps 1-3 until you have a release
    you are happy to deploy to production.
 6. Deploy to live:
-   1. `ssh -p 10022 production.montagu.dide.ic.ac.uk`
-   1. `sudo su`
-   1. `cd /montagu/deploy`
+   1. `ssh -p 10022 montagu@production.montagu.dide.ic.ac.uk`
+   1. `cd deploy`
    1. `./deploy.py --docker-hub`
 7. Use `RELEASE_LOG.md` to know which tickets to update to the 'Deployed' status
 
@@ -26,15 +25,14 @@
 3. `cd montagu`
 4.  2 options here:
 
-    i) To deploy the latest tagged release, run `sudo -E ./deploy.py`
+    i) To deploy the latest tagged release, run `./deploy.py`
 
     ii) To run a specific branch:
     ```
-    sudo git fetch && git checkout <branchname> && git merge && git submodule update --recursive
-    sudo -E ./src/deploy.py
+    git fetch && git checkout <branchname> && git merge && git submodule update --recursive
+    ./src/deploy.py
     ```
     
-    Note the different deploy scripts in i) and i) : `./src/deploy.py` deploys the 
-    contents of the current directory, whereas the top level `./deploy.py` first updates 
-    things to the latest tag. Unfortunately we need to be `sudo` to deploy, because the 
-    tool installs `bb8` as part of the process.
+    Note the different deploy scripts in i) and i) : `./src/deploy.py`
+    deploys the contents of the current directory, whereas the top
+    level `./deploy.py` first updates things to the latest tag.

--- a/deploy.py
+++ b/deploy.py
@@ -30,6 +30,8 @@ def get_version_from_user():
     return tag
 
 if __name__ == "__main__":
+    if os.geteuid() == 0:
+        raise Exception("Please do not run deploy as root user")
     args = docopt.docopt(__doc__)
     version = args["<version>"] or get_version_from_user()
     if args["--docker-hub"]:

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import webbrowser
-from os import chdir
+from os import chdir, geteuid
 from os.path import abspath, dirname
 from time import sleep
 
@@ -151,6 +151,8 @@ def deploy():
 
 
 if __name__ == "__main__":
+    if geteuid() == 0:
+        raise Exception("Please do not run deploy as root user")
     abspath = abspath(__file__)
     chdir(dirname(abspath))
     deploy()


### PR DESCRIPTION
Most of the changes here are documentation changes, and then updating to include changes in bb8 and montagu-bb8; merge these up the dependency chain (bb8, then montagu-bb8 then montagu), updating submodule references as appropriate

https://github.com/vimc/bb8/pull/47 & https://github.com/vimc/montagu-bb8/pull/7