### PR TITLE
VIMC-2947 support switch from reporting portal to orderly web

### DIFF
--- a/clear-docker.sh
+++ b/clear-docker.sh
@@ -12,4 +12,5 @@ fi
 echo "Stopping and removing all Docker containers..."
 docker stop $(docker ps -aq)
 docker rm $(docker ps -aq)
+docker volume prune
 exit 0

--- a/src/compose.py
+++ b/src/compose.py
@@ -11,6 +11,11 @@ def start(settings):
 def stop(settings):
     command = "stop" if settings["persist_data"] else "rm --force --stop"
     run(command, settings)
+    p = Popen(["docker", "system", "prune"], env=get_env(settings), shell=True)
+    p.wait()
+    if p.returncode != 0:
+        raise Exception("An error occurred: docker returned {}".format(
+            p.returncode))
 
 
 def pull(settings):

--- a/src/compose.py
+++ b/src/compose.py
@@ -9,7 +9,7 @@ def start(settings):
 
 
 def stop(settings):
-    command = "down" if settings["persist_data"] else "down --volumes"
+    command = "stop" if settings["persist_data"] else "rm --force --stop"
     run(command, settings)
 
 

--- a/src/compose.py
+++ b/src/compose.py
@@ -10,12 +10,8 @@ def start(settings):
 
 def stop(settings):
     run("stop", settings)
-    if not settings["persist_data"]:
-        p = Popen("docker system prune -a --volumes -f", shell=True)
-        p.wait()
-        if p.returncode != 0:
-            raise Exception("An error occurred: docker returned {}".format(
-                p.returncode))
+    command = "rm" if settings["persist_data"] else "rm -v"
+    run(command, settings)
 
 
 def pull(settings):

--- a/src/compose.py
+++ b/src/compose.py
@@ -10,8 +10,7 @@ def start(settings):
 
 def stop(settings):
     run("stop", settings)
-    command = "rm" if settings["persist_data"] else "rm -v"
-    run(command, settings)
+    run("rm", settings)
 
 
 def pull(settings):

--- a/src/compose.py
+++ b/src/compose.py
@@ -11,7 +11,7 @@ def start(settings):
 def stop(settings):
     command = "stop" if settings["persist_data"] else "rm --force --stop"
     run(command, settings)
-    p = Popen(["docker", "system", "prune"], env=get_env(settings), shell=True)
+    p = Popen("docker system prune -a --volumes -f", shell=True)
     p.wait()
     if p.returncode != 0:
         raise Exception("An error occurred: docker returned {}".format(

--- a/src/compose.py
+++ b/src/compose.py
@@ -10,7 +10,7 @@ def start(settings):
 
 def stop(settings):
     run("stop", settings)
-    run("rm", settings)
+    run("rm -f", settings)
 
 
 def pull(settings):

--- a/src/compose.py
+++ b/src/compose.py
@@ -9,13 +9,13 @@ def start(settings):
 
 
 def stop(settings):
-    command = "stop" if settings["persist_data"] else "rm --force --stop"
-    run(command, settings)
-    p = Popen("docker system prune -a --volumes -f", shell=True)
-    p.wait()
-    if p.returncode != 0:
-        raise Exception("An error occurred: docker returned {}".format(
-            p.returncode))
+    run("stop", settings)
+    if not settings["persist_data"]:
+        p = Popen("docker system prune -a --volumes -f", shell=True)
+        p.wait()
+        if p.returncode != 0:
+            raise Exception("An error occurred: docker returned {}".format(
+                p.returncode))
 
 
 def pull(settings):

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -61,7 +61,7 @@ def _deploy():
     if not is_first_time:
         notifier.post("*Stopping* previous montagu "
                       "on `{}` :hand:".format(settings['instance_name']))
-        service.stop()
+        #service.stop()
 
     # Schedule backups
     if settings["bb8_backup"]:

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -61,7 +61,7 @@ def _deploy():
     if not is_first_time:
         notifier.post("*Stopping* previous montagu "
                       "on `{}` :hand:".format(settings['instance_name']))
-        #service.stop()
+        service.stop()
 
     # Schedule backups
     if settings["bb8_backup"]:

--- a/src/service.py
+++ b/src/service.py
@@ -170,6 +170,10 @@ class MontaguService:
             static_volume.remove(force=True)
         except docker.errors.NotFound:
             return None
+        if not self.settings["persist_data"]:
+            for v in self.volumes:
+                name = self.volume_name(v)
+                self.client.volumes.get(name).remove(force=True)
 
     def pull(self):
         print("Pulling images for Montagu", flush=True)

--- a/src/service.py
+++ b/src/service.py
@@ -161,10 +161,11 @@ class MontaguService:
         print("Stopping Montagu...({}: {})".format(
             self.settings["instance_name"], self.settings["docker_prefix"]),
               flush=True)
+        # always remove the static container
+        self.static.remove(force=True)
         compose.stop(self.settings)
         print("Wiping static file volume")
         try:
-            self.static.remove(force=True)
             static_volume = self.client.volumes.get(self.volume_name("static"))
             static_volume.remove(force=True)
         except docker.errors.NotFound:

--- a/src/service.py
+++ b/src/service.py
@@ -161,23 +161,10 @@ class MontaguService:
         print("Stopping Montagu...({}: {})".format(
             self.settings["instance_name"], self.settings["docker_prefix"]),
               flush=True)
-
-        # As documented in VIMC-805, the orderly container will
-        # respond quickly to an interrupt, but not to whatever docker
-        # stop (via docker-compose stop) is sending. This is
-        # (presumably) a limitation of httpuv and not something I can
-        # see how to work around at the R level. So instead we send an
-        # interrupt signal (SIGINT) just before the stop, and that
-        # seems to bring things down much more quicky.
-        if self.orderly:
-            try:
-                self.orderly.kill("SIGINT")
-            except:
-                print("Killing orderly container failed - continuing")
-                pass
         compose.stop(self.settings)
         print("Wiping static file volume")
         try:
+            self.static.remove(force=True)
             static_volume = self.client.volumes.get(self.volume_name("static"))
             static_volume.remove(force=True)
         except docker.errors.NotFound:

--- a/src/service.py
+++ b/src/service.py
@@ -83,7 +83,7 @@ class MontaguService:
 
     def start_metrics(self):
         # Metrics container has to be started last, after proxy has its SSL cert and is able to serve basic_status
-        self.client.containers.run('nginx/nginx-prometheus-exporter:0.2.0',
+        self.client.containers.run('nginx/nginx-prometheus-exporter:0.4.1',
                                     restart_policy = {"Name": "always"},
                                     ports = {'9113/tcp': 9113},
                                     command = '-nginx.scrape-uri "http://montagu_proxy_1/basic_status"',


### PR DESCRIPTION
Updates the proxy which will now point to the version that proxies OW. Changed the "stop" logic to stop containers rather than bringing down the network.