### PR TITLE
vimc-3496: Increase shared memory size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     restart: always
     logging: *log-journald
     command: ${MONTAGU_DB_CONF}
+    shm_size: 512M
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
Science have hit a problem where the SQL code generated by dbplyr generates parallel aggregate queries and that runs the db out of shared memory.  This question here is exactly the problem that we have: https://meta.discourse.org/t/pg-throws-could-not-resize-shared-memory-segment-error/84744

The solution is to increase the shared memory available to the container via a docker option.  After deploying a version with this change we should be able to do

```
docker exec -it montagu_db_1 df -h /dev/shm
```

and see a much larger number than 64M in Avail. On my machine with the dev settings:

```
$ docker exec -it montagu_db_1 df -h /dev/shm
Filesystem      Size  Used Avail Use% Mounted on
shm             512M  8.0K  512M   1% /dev/shm
```

on production at the moment:

```
$ docker exec -it montagu_db_1 df -h /dev/shm
FFilesystem      Size  Used Avail Use% Mounted on
shm              64M  8.0K   64M   1% /dev/shm
```