### PR TITLE
vimc-3920: Add vis tool (manually)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ token_keypair/
 config/
 src/last_deploy.json
 src/last_restore
+visualisation

--- a/scripts/copy-vis-tool.sh
+++ b/scripts/copy-vis-tool.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -ex
+
+PROXY_CONTAINER=montagu_proxy_1
+ORDERLY_CONTAINER=orderly_web_orderly
+ORDERLY_REPORT=paper-first-public-app
+ORDERLY_ID=20200115-105913-be6fcf5b
+
+ORDERLY_PATH="/orderly/archive/$ORDERLY_REPORT/$ORDERLY_ID"
+WWW_ROOT=/usr/share/nginx/html
+
+docker exec -it $PROXY_CONTAINER mkdir -p $WWW_ROOT/visualisation
+
+mkdir -p visualisation
+docker cp $ORDERLY_CONTAINER:$ORDERLY_PATH visualisation/2020
+docker cp visualisation/2020 $PROXY_CONTAINER:$WWW_ROOT/visualisation


### PR DESCRIPTION
This PR updates the proxy to include vimc-3908 (https://github.com/vimc/montagu-proxy/pull/50) and adds a script to copy the vis tool into place.

Merge the montagu-proxy PR first and update the commit in the submodule.

Currently deployed (with dummy report) on uat:
https://support.montagu.dide.ic.ac.uk:10443/visualisation/2020/