### PR TITLE
vimc-4228 use docker hub for proxy image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     depends_on:
       - api
   proxy:
-    image: ${MONTAGU_REGISTRY}/montagu-reverse-proxy:${MONTAGU_PROXY_VERSION}
+    image: ${VIMC_REGISTRY}/montagu-reverse-proxy:${MONTAGU_PROXY_VERSION}
     restart: always
     logging: *log-journald
     ports:


### PR DESCRIPTION
Should be merged along with https://github.com/vimc/montagu-proxy/pull/54