### PR TITLE
Only configure static server if configured to copy files

### DIFF
--- a/src/deploy.py
+++ b/src/deploy.py
@@ -141,6 +141,8 @@ def configure_montagu(service, data_exists):
 
     if service.settings["include_guidance_reports"]:
         configure_contrib_portal(service)
+
+    if service.settings["copy_static_files"]:
         configure_static_server(service, token_keypair_paths)
 
 


### PR DESCRIPTION
So it seems that cloning the static server is going to break the deploy (for still mysterious reasons), so it will be a happy coincidence if it turns out that we can retire the static server at this point. 

This is a temporary fix to ensure that we can continue to test other stuff on uat - for some reason the configuration of the static server was being switched on the guidance reports setting rather than the static files setting. I've just updated to use that setting instead. 

We ALSO need to either retire static server or fix it!