### PR TITLE
vimc-4224 Provide smtp credetials for real smtp server

### DIFF
--- a/src/service_config/task_queue_config.py
+++ b/src/service_config/task_queue_config.py
@@ -2,6 +2,7 @@ import yaml
 import paths
 from os.path import join
 from docker_helpers import docker_cp, docker_cp_from
+from settings import get_secret
 
 
 def configure_task_queue(service, montagu_user, montagu_password,
@@ -35,13 +36,14 @@ def configure_task_queue(service, montagu_user, montagu_password,
     config["tasks"]["diagnostic_reports"]["reports"] = diag_reports
 
     smtp = config["servers"]["smtp"]
-    smtp["from"] = "montagu-help@imperial.ac.uk"
+    smtp["from"] = "montagu-notifications@imperial.ac.uk"
     if fake_smtp:
         smtp["host"] = "montagu_fake_smtp_server_1"
     else:
         smtp["host"] = "smtp.cc.ic.ac.uk"
         smtp["port"] = 587
-
+        smtp["user"] = "montagu"
+        smtp["password"] = get_secret("email/password")
 
     print("- writing config to container")
     with open(local_config_file, "w") as file:


### PR DESCRIPTION
Again, a bit tricky to test as should only occur in production. Can be tested locally by setting `fake_smtp` to false in `montagu-deploy.json` before running `src/deploy.py`, then checking the contents of the deployed config file with `docker exec montagu_task-queue_1 cat config/config.yml`