### PR TITLE
vimc-4295 Added timeout to generate diagnostic report config script

### DIFF
--- a/src/generate_real_diagnostic_reports_config.py
+++ b/src/generate_real_diagnostic_reports_config.py
@@ -10,6 +10,7 @@ from os.path import abspath, dirname, join
 def generate():
     report = "native-diagnostics-burden-report-drafts"
     subject = "VIMC diagnostic report: {touchstone} - {group} - {disease}"
+    timeout = 1800
 
     vimc_recipients = [
         "k.gaythorpe@imperial.ac.uk",
@@ -92,7 +93,8 @@ def generate():
                 "success_email": {
                     "recipients": copy(vimc_recipients) + pi_email,
                     "subject": subject
-                }
+                },
+                "timeout": timeout
             }]
 
     file_path = join(paths.container_config, "task_queue", "real_diagnostic_reports.yml")


### PR DESCRIPTION
I have not committed the regenerated config, as we want this to be empty for now. Should be ok to regenerate once https://github.com/vimc/montagu/pull/188 is merged