### PR TITLE
vimc-4315 Set use_additional_email_recipients to false for diagnostics task

### DIFF
--- a/src/service_config/task_queue_config.py
+++ b/src/service_config/task_queue_config.py
@@ -29,6 +29,9 @@ def configure_task_queue(service, montagu_email, montagu_password,
     montagu["user"] = montagu_email
     montagu["password"] = montagu_password
 
+    # We do not email estimate uploaders for now
+    #config["tasks"]["use_additional_recipients"] = False
+
     # Task queue needs orderly-web url without /api/v1 suffix
     ow_url_trimmed = orderly_web_url.replace("/api/v1", "")
     config["servers"]["orderlyweb"]["url"] = ow_url_trimmed

--- a/src/test.py
+++ b/src/test.py
@@ -77,7 +77,8 @@ def task_queue_integration_tests():
         app = celery.Celery(broker="pyamqp://guest@localhost//",
                             backend="rpc://")
         sig = "run-diagnostic-reports"
-        args = ["testGroup", "testDisease", "testTouchstone"]
+        args = ["testGroup", "testDisease", "testTouchstone",
+                "notincluded@example.com"]
         signature = app.signature(sig, args)
         versions = signature.delay().get()
         assert len(versions) == 1
@@ -86,6 +87,9 @@ def task_queue_integration_tests():
         assert len(emails) == 1
         s = "VIMC diagnostic report: testTouchstone - testGroup - testDisease"
         assert emails[0]["subject"] == s
+        # should not include the additional recipient provided, as we are
+        # currently setting use_additional_recipients to false in config
+        assert len(emails[0]["to"]["value"]) == 0
         assert emails[0]["to"]["value"][0][
                    "address"] == "minimal_modeller@example.com"
 


### PR DESCRIPTION
When this is merged, it should be ok to regenerate the task config