### PR TITLE
vimc-4475 Remove use of private docker registry from release scripts

### DIFF
--- a/ReleaseProcess.md
+++ b/ReleaseProcess.md
@@ -18,7 +18,7 @@ If this is first time release then clone this repo on your local machine and run
 1. The script will prompt you to review changes and push tags via
    ```
     git push --follow-tags
-    ./scripts/release/tag-images.py tag --publish latest
+    ./scripts/release/tag-images.py latest
     ```
 1. Check build has passed in Buildkite
 1. Connect to the UAT machine and deploy there (see below)

--- a/scripts/release/make-release.py
+++ b/scripts/release/make-release.py
@@ -113,7 +113,7 @@ Completed successfully. No changes have been pushed, so please review and then
 push using: 
 
   git push --follow-tags
-  ./scripts/release/tag-images.py tag --publish latest
+  ./scripts/release/tag-images.py latest
 
 Tickets have been tagged in YouTrack, so post release do the following:
 * Go to 

--- a/scripts/release/tag-images.py
+++ b/scripts/release/tag-images.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Tags images used in a particular release and pushes the tags into
-https://hub.docker.com/u/vimc.
+https://hub.docker.com/u/vimc.  Use tag 'latest' to select the most recent
+conforming git tag (this will not set things to be the docker 'latest' tag
+though).
 
 Usage:
   tag-images.py <version>


### PR DESCRIPTION
Apparently we haven't done a proper montagu release since we removed the private docker registry. This branch simplifies the `tag-images` script by removing the option to publish to the vimc registry - because that's what it always uses now. Also updates instructions to user. 