### PR TITLE
vimc-4438 Updated public datavis tool version

### DIFF
--- a/scripts/copy-vis-tool.sh
+++ b/scripts/copy-vis-tool.sh
@@ -4,7 +4,7 @@ set -ex
 PROXY_CONTAINER=montagu_proxy_1
 ORDERLY_CONTAINER=orderly_web_orderly
 ORDERLY_REPORT=paper-first-public-app
-ORDERLY_ID=20200727-143757-d6a26611
+ORDERLY_ID=20210119-181839-c82a6c22
 
 ORDERLY_PATH="/orderly/archive/$ORDERLY_REPORT/$ORDERLY_ID"
 WWW_ROOT=/usr/share/nginx/html


### PR DESCRIPTION
I think this should be the last PR for the paper 1 datavis tool! Just updates the report version to this, run on production yesterday with the latest changes (paper link, new colours, gavi73): https://montagu.vaccineimpact.org/reports/report/paper-first-public-app/20210119-181839-c82a6c22