### PR TITLE
Update required version of psycopg2

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -10,6 +10,8 @@ function cleanup() {
 trap cleanup EXIT
 
 cp settings/buildkite.json src/montagu-deploy.json
+sudo apt-get update
+sudo apt-get install -y libpq-dev
 pip3 install --quiet -r src/requirements.txt
 ./src/deploy.py
 ./src/test.py $@ --simulate-restart

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 docker
 requests==2.20.1
 pystache==0.5.4
-psycopg2==2.7.3.2
+psycopg2==2.8.6
 docopt
 pyyaml==5.3.1
 celery[redis]


### PR DESCRIPTION
Previous version will not work with python 3.8

This is required for https://github.com/vimc/montagu-machine/pull/24