### PR TITLE
vimc-6327 Add burden estimate files volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       # If password_group is 'production' then emails will be really sent, and this
       # volume will remain empty. Otherwise emails are written to disk here.
       - emails:/tmp/montagu_emails
+      - burden_estimate_files:/tmp/burden_estimate_files
   db:
     image: ${VIMC_REGISTRY}/montagu-db:${MONTAGU_DB_VERSION}
     restart: always
@@ -78,6 +79,7 @@ services:
       - "6379:6379"
     volumes:
       - mq:/data
+      - burden_estimate_files:/burden_estimate_files
   flower:
     image: mher/flower:0.9.5
     restart: always
@@ -104,3 +106,4 @@ volumes:
   guidance_volume:
   emails:
   mq:
+  burden_estimate_files:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,6 @@ services:
       - "6379:6379"
     volumes:
       - mq:/data
-      - burden_estimate_files:/burden_estimate_files
   flower:
     image: mher/flower:0.9.5
     restart: always
@@ -98,6 +97,8 @@ services:
       - mq
     environment:
       - YOUTRACK_TOKEN=$YOUTRACK_TOKEN
+    volumes:
+      - burden_estimate_files:/home/worker/burden_estimate_files
 volumes:
   static_logs:
   static_volume:

--- a/src/service_config/api_config.py
+++ b/src/service_config/api_config.py
@@ -25,9 +25,6 @@ def configure_api(service, db_password: str, keypair_paths, hostname, is_prod: b
     generate_api_config_file(service, config_path, db_password, hostname,
                              is_prod, orderly_web_api_url, celery_flower_host)
 
-    print("- Making burden estimate files accessible to task queue")
-    service.api.exec_run("chmod a+w tmp/burden_estimate_files")
-
     print("- Sending go signal to API")
     service.api.exec_run("touch {}/go_signal".format(config_path))
 

--- a/src/service_config/api_config.py
+++ b/src/service_config/api_config.py
@@ -25,6 +25,9 @@ def configure_api(service, db_password: str, keypair_paths, hostname, is_prod: b
     generate_api_config_file(service, config_path, db_password, hostname,
                              is_prod, orderly_web_api_url, celery_flower_host)
 
+    print("- Making burden estimate files accessible to task queue")
+    service.api.exec_run("chmod a+w tmp/burden_estimate_files")
+
     print("- Sending go signal to API")
     service.api.exec_run("touch {}/go_signal".format(config_path))
 

--- a/src/service_config/task_queue_config.py
+++ b/src/service_config/task_queue_config.py
@@ -57,7 +57,7 @@ def configure_task_queue(service,
         config["servers"]["youtrack"]["token"] = \
             get_secret("vimc-robot/youtrack-task-queue-token")
 
-    config["archive_folder_contents"]["min_file_age_seconds"] = 3600
+    config["tasks"]["archive_folder_contents"]["min_file_age_seconds"] = 3600
 
     print("- writing config to container")
     with open(local_config_file, "w") as file:

--- a/src/service_config/task_queue_config.py
+++ b/src/service_config/task_queue_config.py
@@ -56,6 +56,9 @@ def configure_task_queue(service,
     if is_prod:
         config["servers"]["youtrack"]["token"] = \
             get_secret("vimc-robot/youtrack-task-queue-token")
+
+    config["archive_folder_contents"]["min_file_age_seconds"] = 3600
+
     print("- writing config to container")
     with open(local_config_file, "w") as file:
         yaml.dump(config, file)


### PR DESCRIPTION
This branch:
- adds a volume to docker compose, `burden_estimate_files`, which is used by the api and task queue containers 
- Configures the task queue to use a minimum file age of 1 hour when archiving files. 
- Opens the permissions to the volume when the api starts, so that it is accessible to the task queue worker user

Deployed to UAT, or you can test locally with `src/deploy.py`. 

You can run the task with:
`curl -X POST -d '{"args":["burden_estimate_files"]}' http://localhost:5555/api/task/send-task/archive_folder_contents`

Any files in the volume (at the top level) which are older than 1 hour should be deleted. I've left a file, `test.txt`, in the volume on UAT, to make this easy to test, or you could edit the config file in the task queue container to drop the minimum file age. 

To list files in the volume:
`docker exec montagu_api_1 ls tmp/burden_estimate_files`

To add a file to the volume:
`docker exec montagu_api_1 touch tmp/burden_estimate_files/test.txt`
